### PR TITLE
fix(ci): ko pipeline permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Current permissions are not sufficient and fail with:

>  Error: failed to publish images: error publishing ko://github.com/apricote/releaser-pleaser/cmd/rp: writing sbom: POST https://ghcr.io/v2/apricote/releaser-pleaser/blobs/uploads/: DENIED: installation not allowed to Write organization package