### PR TITLE
ci: run on pr updates from main branch

### DIFF
--- a/.github/workflows/releaser-pleaser.yaml
+++ b/.github/workflows/releaser-pleaser.yaml
@@ -3,8 +3,8 @@ name: releaser-pleaser
 on:
   push:
     branches: [main]
-  # TODO: use pull_request_target to avoid tainting the actual release PR with code from open feature pull requests
-  pull_request:
+  # Using pull_request_target to avoid tainting the actual release PR with code from open feature pull requests
+  pull_request_target:
     types:
       - edited
       - labeled
@@ -14,10 +14,13 @@ permissions: {}
 
 jobs:
   releaser-pleaser:
+    # TODO: if: push or pull_request.closed
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
With `pull_request`, we run in the context of the pull request branch.

- This means we run with the code from the PR branch, possibly breaking the current release PR for this repo with in-progress, unreviewed changes.
- This means that the secret is not available on Pull Requests from forks.

Switching to `pull_request_target` means we always run in the scope of the original repository. The secret is available and the code is checked out from our main branch.

`pull_request_target` has security considerations, but they do not apply here as we do not check out or run code from the (external, malicious) PR.