### PR TITLE
feat: less repetitive entries for for prerelease changelogs

### DIFF
--- a/releasepr.go
+++ b/releasepr.go
@@ -59,9 +59,8 @@ func NewReleasePullRequest(head, branch, version, changelogEntry string) (*Relea
 }
 
 type ReleaseOverrides struct {
-	Prefix string
-	Suffix string
-	// TODO: Doing the changelog for normal releases after previews requires to know about this while fetching the commits
+	Prefix          string
+	Suffix          string
 	NextVersionType NextVersionType
 }
 
@@ -89,6 +88,17 @@ func (n NextVersionType) String() string {
 		return "alpha"
 	default:
 		return ""
+	}
+}
+
+func (n NextVersionType) IsPrerelease() bool {
+	switch n {
+	case NextVersionTypeRC, NextVersionTypeBeta, NextVersionTypeAlpha:
+		return true
+	case NextVersionTypeUndefined, NextVersionTypeNormal:
+		return false
+	default:
+		return false
 	}
 }
 

--- a/releaserpleaser.go
+++ b/releaserpleaser.go
@@ -178,7 +178,15 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 		logger.InfoContext(ctx, "no latest tag found")
 	}
 
-	releasableCommits, err := rp.forge.CommitsSince(ctx, releases.Stable)
+	// By default, we want to show everything that has happened since the last stable release
+	lastReleaseCommit := releases.Stable
+	if releaseOverrides.NextVersionType.IsPrerelease() {
+		// if the new release will be a prerelease,
+		// only show changes since the latest release (stable or prerelease)
+		lastReleaseCommit = releases.Latest
+	}
+
+	releasableCommits, err := rp.forge.CommitsSince(ctx, lastReleaseCommit)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Right now we always show all new releasable commits since the last _stable_ release.

If a project publishes multiple pre-releases in a row, they all repeat the same lines with a few new additions.

On the other hand, when we cut a stable release, we do want to show all changes since the last stable release, as we can not expect users to read the changelog of pre-releases.

As a compromise, the code now looks at the type of release that is being created, and decides based on that if we will look at STABLE..HEAD (stable release) or LATEST..HEAD (pre-release).

Close #33