### PR TITLE
feat(cli): show release PR url in log messages

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -13,6 +13,7 @@ type Forge interface {
 	RepoURL() string
 	CloneURL() string
 	ReleaseURL(version string) string
+	PullRequestURL(id int) string
 
 	GitAuth() transport.AuthMethod
 

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -51,6 +51,10 @@ func (g *GitHub) ReleaseURL(version string) string {
 	return fmt.Sprintf("https://github.com/%s/%s/releases/tag/%s", g.options.Owner, g.options.Repo, version)
 }
 
+func (g *GitHub) PullRequestURL(id int) string {
+	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", g.options.Owner, g.options.Repo, id)
+}
+
 func (g *GitHub) GitAuth() transport.AuthMethod {
 	return &http.BasicAuth{
 		Username: g.options.Username,

--- a/releaserpleaser.go
+++ b/releaserpleaser.go
@@ -300,7 +300,7 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		logger.InfoContext(ctx, "opened pull request", "pr.title", pr.Title, "pr.id", pr.ID)
+		logger.InfoContext(ctx, "opened pull request", "pr.title", pr.Title, "pr.id", pr.ID, "pr.url", rp.forge.PullRequestURL(pr.ID))
 	} else {
 		pr.SetTitle(rp.targetBranch, nextVersion)
 
@@ -317,7 +317,7 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		logger.InfoContext(ctx, "updated pull request", "pr.title", pr.Title, "pr.id", pr.ID)
+		logger.InfoContext(ctx, "updated pull request", "pr.title", pr.Title, "pr.id", pr.ID, "pr.url", rp.forge.PullRequestURL(pr.ID))
 	}
 
 	return nil


### PR DESCRIPTION
Makes navigating to the PR way easier when looking at the logs.

This requires a new `Forge.PullRequestURL()` method that needs to be implemented for all forges.