### PR TITLE
fix(parser): invalid handling of title with new line

### DIFF
--- a/internal/commitparser/conventionalcommits/conventionalcommits.go
+++ b/internal/commitparser/conventionalcommits/conventionalcommits.go
@@ -3,6 +3,7 @@ package conventionalcommits
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/leodido/go-conventionalcommits"
 	"github.com/leodido/go-conventionalcommits/parser"
@@ -32,7 +33,7 @@ func (c *Parser) Analyze(commits []git.Commit) ([]commitparser.AnalyzedCommit, e
 	analyzedCommits := make([]commitparser.AnalyzedCommit, 0, len(commits))
 
 	for _, commit := range commits {
-		msg, err := c.machine.Parse([]byte(commit.Message))
+		msg, err := c.machine.Parse([]byte(strings.TrimSpace(commit.Message)))
 		if err != nil {
 			c.logger.Warn("failed to parse message of commit, skipping", "commit.hash", commit.Hash, "err", err)
 			continue

--- a/internal/commitparser/conventionalcommits/conventionalcommits_test.go
+++ b/internal/commitparser/conventionalcommits/conventionalcommits_test.go
@@ -34,6 +34,19 @@ func TestAnalyzeCommits(t *testing.T) {
 			wantErr:         assert.NoError,
 		},
 		{
+			// GitLab seems to create commits with pattern "scope: message\n" if no body is added.
+			// This has previously caused a parser error "missing a blank line".
+			// We added a workaround with `strings.TrimSpace()` and this test make sure that it does not break again.
+			name: "handles title with new line",
+			commits: []git.Commit{
+				{
+					Message: "aksdjaklsdjka",
+				},
+			},
+			expectedCommits: []commitparser.AnalyzedCommit{},
+			wantErr:         assert.NoError,
+		},
+		{
 			name: "drops unreleasable",
 			commits: []git.Commit{
 				{


### PR DESCRIPTION
GitLab generates commit messages of the pattern "scope: message\n" if no body is present. This throws up the conventional commits parser we use, and results in the error message "missing a blank line".

We now `strings.TrimSpace()` the commit message to avoid this problem.

Related to #4 