### PR TITLE
fix(gitlab): use project path wherever possible

### DIFF
--- a/cmd/rp/cmd/run.go
+++ b/cmd/rp/cmd/run.go
@@ -62,8 +62,7 @@ func run(cmd *cobra.Command, _ []string) error {
 		logger.DebugContext(ctx, "using forge GitLab")
 		f, err = gitlab.New(logger, &gitlab.Options{
 			Options: forgeOptions,
-			Path:    flagOwner,
-			Repo:    flagRepo,
+			Path:    fmt.Sprintf("%s/%s", flagOwner, flagRepo),
 		})
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to create client", "err", err)


### PR DESCRIPTION
Turns out that all we need is the path, and not the project id. The path is way more user friendly, and we can easily get it from a CI variable or combine it from the namespace & project name.

As GitLab support is unreleased, I will remove this commit from the Changelog:

```rp-commits
```