### PR TITLE
feat(gitlab): GitLab CI/CD component

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,15 @@
+stages: [release]
+
+# For the GitLab CI/CD component to be usable, it needs to be published in
+# the CI/CD catalog. This happens on new releases.
+# As the primary tagging happens on GitHub, we only react to pushed tags
+# and create a corresponding GitLab Release.
+create-release:
+  stage: release
+  image: registry.gitlab.com/gitlab-org/release-cli:latest
+  script: echo "Creating release $CI_COMMIT_TAG"
+  rules:
+    - if: $CI_COMMIT_TAG
+  release:
+    tag_name: "$CI_COMMIT_TAG"
+    description: "$CI_COMMIT_TAG_MESSAGE"

--- a/templates/run.yml
+++ b/templates/run.yml
@@ -1,0 +1,36 @@
+spec:
+  inputs:
+    # Remember to update docs/reference/gitlab-ci-component.md
+    branch:
+      default: main
+      description: "This branch is used as the target for releases."
+
+    token:
+      description: "GitLab token for creating and updating release MRs."
+
+    extra-files:
+      description: 'List of files that are scanned for version references.'
+      default: ""
+
+    stage:
+      default: build
+      description: 'Defines the build stage'
+    # Remember to update docs/reference/gitlab-ci-component.md
+---
+
+releaser-pleaser:
+  stage: $[[ inputs.stage ]]
+  rules:
+    # There is no way to run a pipeline when the MR description is updated :(
+    - if: $CI_COMMIT_BRANCH == "$[[ inputs.branch ]]"
+  image:
+    name: ghcr.io/apricote/releaser-pleaser:v0.4.0-beta.0 # x-releaser-pleaser-version
+    entrypoint: [""]
+  variables:
+    GITLAB_TOKEN: $[[ inputs.token ]]
+  script:
+    - |
+      rp run \
+        --forge=gitlab \
+        --branch=$[[ inputs.branch ]] \
+        --extra-files=$[[ inputs.extra-files ]]


### PR DESCRIPTION
This adds a GitLab CI/CD component that can be `included` in users GitLab CI configuration to integrate releaser-pleaser.

Unlike the GitHub Action, this can not easily run whenever a merge request description is changed, only when changes are pushed to main.

Related to #4.
