### PR TITLE
feat: add shell to container image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,3 +1,6 @@
 defaultPlatforms:
   - linux/arm64
   - linux/amd64
+
+# Need a shell for gitlab-ci
+defaultBaseImage: cgr.dev/chainguard/busybox


### PR DESCRIPTION
Images used in GitLab CI need to have a shell included, otherwise the job could not be started.

This replaces the default `cgr.dev/chainguard/static` base image with `cgr.dev/chainguard/busybox`. Busybox is the smallest image that includes a functional shell.

Needed for #55.