### PR TITLE
feat(changelog): omit version heading in forge release notes

### DIFF
--- a/internal/changelog/changelog.md.tpl
+++ b/internal/changelog/changelog.md.tpl
@@ -1,22 +1,24 @@
-## [{{.Version}}]({{.VersionLink}})
-{{- if .Prefix }}
-{{ .Prefix }}
+{{define "entry" -}}
+- {{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}}
+{{ end }}
+
+{{- if not .Formatting.HideVersionTitle }}
+## [{{.Data.Version}}]({{.Data.VersionLink}})
 {{ end -}}
-{{- if (gt (len .Features) 0) }}
+{{- if .Data.Prefix }}
+{{ .Data.Prefix }}
+{{ end -}}
+{{- with .Data.Commits.feat }}
 ### Features
 
-{{ range .Features -}}
-- {{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}}
-{{ end -}}
+{{ range . -}}{{template "entry" .}}{{end}}
 {{- end -}}
-{{- if (gt (len .Fixes) 0) }}
+{{- with .Data.Commits.fix }}
 ### Bug Fixes
 
-{{ range .Fixes -}}
-- {{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}}
-{{ end -}}
+{{ range . -}}{{template "entry" .}}{{end}}
 {{- end -}}
 
-{{- if .Suffix }}
-{{ .Suffix }}
+{{- if .Data.Suffix }}
+{{ .Data.Suffix }}
 {{ end }}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -168,7 +168,8 @@ This version is compatible with flux-compensator v2.2 - v2.9.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewChangelogEntry(slog.Default(), tt.args.analyzedCommits, tt.args.version, tt.args.link, tt.args.prefix, tt.args.suffix)
+			data := New(commitparser.ByType(tt.args.analyzedCommits), tt.args.version, tt.args.link, tt.args.prefix, tt.args.suffix)
+			got, err := Entry(slog.Default(), DefaultTemplate(), data, Formatting{})
 			if !tt.wantErr(t, err) {
 				return
 			}

--- a/internal/commitparser/commitparser.go
+++ b/internal/commitparser/commitparser.go
@@ -15,3 +15,18 @@ type AnalyzedCommit struct {
 	Scope          *string
 	BreakingChange bool
 }
+
+// ByType groups the Commits by the type field. Used by the Changelog.
+func ByType(in []AnalyzedCommit) map[string][]AnalyzedCommit {
+	out := map[string][]AnalyzedCommit{}
+
+	for _, commit := range in {
+		if out[commit.Type] == nil {
+			out[commit.Type] = make([]AnalyzedCommit, 0, 1)
+		}
+
+		out[commit.Type] = append(out[commit.Type], commit)
+	}
+
+	return out
+}


### PR DESCRIPTION
The forge ui usually shows the release name right above the description, so this removes an unecessary duplicate bit of information.

In addition this also cleans up the changelog interface a bit and moves functionality where it belongs. Prepares a bit for custom changelogs in the future.

Closes #32