### PR TITLE
ci(mirror): fix missing lfs files on push

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -15,6 +15,8 @@ jobs:
         with:
           # Need all to fetch all tags so we can push them
           fetch-depth: 0
+          # Required so they can be pushed too
+          lfs: true
 
       - name: Add Remote
         env:


### PR DESCRIPTION
Job failed after adding new Git LFS files with the error:

```
Git LFS upload failed:
Uploading LFS objects:   0% (0/3), 0 B | 0 B/s, done.
  (missing) docs/tutorials/gitlab-access-token.png (31b485bbe031443c4bfa0d39514dc7e5d524925aa877848def93ee40f69a1897)
  (missing) docs/tutorials/gitlab-settings-merge-method.png (b853625854582a66ab2438f11e6001a88bcb276225abed536ba68617bde324db)
  (missing) docs/tutorials/gitlab-settings-squash.png (0ce9b9826229851e961ef55d91cb9ba91ca9ca4d955a932d9ff6b10d04788c29)
hint: Your push was rejected due to missing or corrupt local objects.
hint: You can disable this check with: `git config lfs.allowincompletepush true`
error: failed to push some refs to 'https://gitlab.com/apricote/releaser-pleaser.git'
Error: Process completed with exit code 1.
```

Pulling the assets with `lfs: true` makes them available for push.