### PR TITLE
fix(gitlab): release not created when release pr was squashed

### DIFF
--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -176,8 +176,8 @@ func (g *GitLab) prForCommit(ctx context.Context, commit git.Commit) (*git.PullR
 
 	var mergeRequest *gitlab.MergeRequest
 	for _, mr := range associatedMRs {
-		// We only look for the MR that has this commit set as the "merge commit" => The result of squashing this branch onto main
-		if mr.MergeCommitSHA == commit.Hash {
+		// We only look for the MR that has this commit set as the "merge/squash commit" => The result of squashing this branch onto main
+		if mr.MergeCommitSHA == commit.Hash || mr.SquashCommitSHA == commit.Hash {
 			mergeRequest = mr
 			break
 		}
@@ -387,9 +387,12 @@ func gitlabMRToReleasePullRequest(pr *gitlab.MergeRequest) *releasepr.ReleasePul
 		}
 	}
 
+	// Commit SHA is saved in either [MergeCommitSHA] or [SquashCommitSHA] depending on which merge method was used.
 	var releaseCommit *git.Commit
 	if pr.MergeCommitSHA != "" {
 		releaseCommit = &git.Commit{Hash: pr.MergeCommitSHA}
+	} else if pr.SquashCommitSHA != "" {
+		releaseCommit = &git.Commit{Hash: pr.SquashCommitSHA}
 	}
 
 	return &releasepr.ReleasePullRequest{


### PR DESCRIPTION
When the release pull request was squashed on GitLab, the release creation fails with error

    Error: failed to create pending releases: pull request is missing the merge commit

This fixes the problem by checking both `MergeCommitSHA` and `SquashCommitSHA` and using whichever is set.