### PR TITLE
feat: remove gitlab ci stage input and run job as soon as possible

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages: [ release ]
 # and create a corresponding GitLab Release.
 create-release:
   stage: release
+  needs: []
   image: registry.gitlab.com/gitlab-org/release-cli:v0.19.0
   script: echo "Creating release $CI_COMMIT_TAG"
   rules:

--- a/docs/tutorials/gitlab.md
+++ b/docs/tutorials/gitlab.md
@@ -63,19 +63,29 @@ In the section "Variables" click on the "Add variable" button to open the form f
 Create or open your `.gitlab-ci.yml` and add the following include to your configuration:
 
 ```yaml
-stages: [build]
-
 include:
   - component: $CI_SERVER_FQDN/apricote/releaser-pleaser/run@v0.4.0-beta.1
     inputs:
       token: $RELEASER_PLEASER_TOKEN
 ```
 
-> You can set the `stage` input if you want to run `releaser-pleaser` during a different stage.
+> You can override the `releaser-pleaser` job if you want to tweak the job definition:
+>
+> ```yaml
+> stages: [release]
+>
+> include:
+>   - component: $CI_SERVER_FQDN/apricote/releaser-pleaser/run@v0.4.0-beta.1
+>     inputs:
+>       token: $RELEASER_PLEASER_TOKEN
+>
+> releaser-pleaser:
+>   stage: release
+> ```
 
 <div class="warning">
 
-If you want to use `releaser-pleaser` on a self-managed GitLab instance, you need to mirror the GitLab.com component to your instance. See the official [GitLab documentation for details](https://docs.gitlab.com/ee/ci/components/#use-a-gitlabcom-component-in-a-self-managed-instance). 
+If you want to use `releaser-pleaser` on a self-managed GitLab instance, you need to mirror the GitLab.com component to your instance. See the official [GitLab documentation for details](https://docs.gitlab.com/ee/ci/components/#use-a-gitlabcom-component-in-a-self-managed-instance).
 
 </div>
 

--- a/templates/run.yml
+++ b/templates/run.yml
@@ -12,14 +12,12 @@ spec:
       description: 'List of files that are scanned for version references.'
       default: ""
 
-    stage:
-      default: build
-      description: 'Defines the build stage'
     # Remember to update docs/reference/gitlab-ci-component.md
 ---
 
 releaser-pleaser:
-  stage: $[[ inputs.stage ]]
+  stage: build
+  needs: []
   rules:
     # There is no way to run a pipeline when the MR description is updated :(
     - if: $CI_COMMIT_BRANCH == "$[[ inputs.branch ]]"


### PR DESCRIPTION
- Remove the stage input, users can override the `releaser-pleaser` job if needed.
- Run the `releaser-pleaser` job as soon as possible using `needs: []`.