### PR TITLE
fix(action): container image reference used wrong syntax

### DIFF
--- a/.github/workflows/releaser-pleaser.yaml
+++ b/.github/workflows/releaser-pleaser.yaml
@@ -34,7 +34,7 @@ jobs:
       - run: ko build --bare --local --tags ci github.com/apricote/releaser-pleaser/cmd/rp
 
       - run: mkdir -p .github/actions/releaser-pleaser
-      - run: "sed -i 's|image: .*$|image: ghcr.io/apricote/releaser-pleaser:ci|g' action.yml"
+      - run: "sed -i 's|image: .*$|image: docker://ghcr.io/apricote/releaser-pleaser:ci|g' action.yml"
 
       # Dogfood the action to make sure it works for users.
       - name: releaser-pleaser

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
 outputs: {}
 runs:
   using: 'docker'
-  image: ghcr.io/apricote/releaser-pleaser:v0.4.1 # x-releaser-pleaser-version
+  image: docker://ghcr.io/apricote/releaser-pleaser:v0.4.1 # x-releaser-pleaser-version
   args:
     - run
     - --forge=github


### PR DESCRIPTION
The current value caused the following error when running the action in a different repository:

    Error: 'ghcr.io/apricote/releaser-pleaser:v0.4.1' should be either '[path]/Dockerfile' or 'docker://image[:tag]'.

Not sure why this did not come up before, as we are also using the same format for the CI in this repository, even if we use another tag.