### PR TITLE
test: ensure commit with body can be parsed

### DIFF
--- a/internal/commitparser/conventionalcommits/conventionalcommits_test.go
+++ b/internal/commitparser/conventionalcommits/conventionalcommits_test.go
@@ -125,6 +125,24 @@ func TestAnalyzeCommits(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+
+		{
+			name: "success with body",
+			commits: []git.Commit{
+				{
+					Message: "feat: some thing (hz/fl!144)\n\nFixes #15\n\nDepends on !143",
+				},
+			},
+			expectedCommits: []commitparser.AnalyzedCommit{
+				{
+					Commit:         git.Commit{Message: "feat: some thing (hz/fl!144)\n\nFixes #15\n\nDepends on !143"},
+					Type:           "feat",
+					Description:    "some thing (hz/fl!144)",
+					BreakingChange: false,
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Seems like the commit parser cannot handle a commit body without thinking it is a trailer.

Having a commit body should be supported.

Related to https://github.com/apricote/releaser-pleaser/issues/99
