### PR TITLE
feat(gitlab): make job dependencies configurable and run immediately

### DIFF
--- a/docs/reference/gitlab-cicd-component.md
+++ b/docs/reference/gitlab-cicd-component.md
@@ -10,7 +10,9 @@ It is being distributed through the CI/CD Catalog: [apricote/releaser-pleaser](h
 
 The `apricote/releaser-pleaser` action is released together with `releaser-pleaser` and they share the version number.
 
-The component does not support floating tags (e.g. `v1`) right now ([#31](https://github.com/apricote/releaser-pleaser/issues/31)). You have to use the full version or commit SHA instead: `apricote/releaser-pleaser@v0.4.0`.
+The component does not support floating tags (e.g.
+`v1`) right now ([#31](https://github.com/apricote/releaser-pleaser/issues/31)). You have to use the full version or commit SHA instead:
+`apricote/releaser-pleaser@v0.4.0`.
 
 ## Inputs
 
@@ -21,3 +23,5 @@ The following inputs are supported by the component.
 | `branch`               | This branch is used as the target for releases.           |  `main` |                                                             `master` |
 | `token` (**required**) | GitLab access token for creating and updating release PRs |         |                                            `$RELEASER_PLEASER_TOKEN` |
 | `extra-files`          | List of files that are scanned for version references.    |    `""` | <pre><code>version/version.go<br>deploy/deployment.yaml</code></pre> |
+| `stage`                | Stage the job runs in. Must exists.                       | `build` |                                                               `test` |
+| `needs`                | Other jobs the releaser-pleaser job depends on.           |    `[]` |              <pre><code>- validate-foo<br>- prepare-bar</code></pre> |

--- a/templates/run.yml
+++ b/templates/run.yml
@@ -15,17 +15,23 @@ spec:
     stage:
       default: build
       description: 'Defines the build stage'
+
+    needs:
+      default: [ ]
+      type: array
+      description: 'Dependencies of the created Job'
     # Remember to update docs/reference/gitlab-ci-component.md
 ---
 
 releaser-pleaser:
   stage: $[[ inputs.stage ]]
+  needs: $[[ inputs.needs ]]
   rules:
     # There is no way to run a pipeline when the MR description is updated :(
     - if: $CI_COMMIT_BRANCH == "$[[ inputs.branch ]]"
   image:
     name: ghcr.io/apricote/releaser-pleaser:v0.4.2 # x-releaser-pleaser-version
-    entrypoint: [""]
+    entrypoint: [ "" ]
   variables:
     GITLAB_TOKEN: $[[ inputs.token ]]
   script:


### PR DESCRIPTION
In the CI/CD component, make the jobs `needs` setting configurable through an input and change the default to `[]`. This will cause the job to run immediately.