### PR TITLE
fix: use commits with slightly invalid messages in release notes

### DIFF
--- a/internal/commitparser/conventionalcommits/conventionalcommits_test.go
+++ b/internal/commitparser/conventionalcommits/conventionalcommits_test.go
@@ -125,6 +125,24 @@ func TestAnalyzeCommits(t *testing.T) {
 			},
 			wantErr: assert.NoError,
 		},
+
+		{
+			name: "success with body",
+			commits: []git.Commit{
+				{
+					Message: "feat: some thing (hz/fl!144)\n\nFixes #15\n\nDepends on !143",
+				},
+			},
+			expectedCommits: []commitparser.AnalyzedCommit{
+				{
+					Commit:         git.Commit{Message: "feat: some thing (hz/fl!144)\n\nFixes #15\n\nDepends on !143"},
+					Type:           "feat",
+					Description:    "some thing (hz/fl!144)",
+					BreakingChange: false,
+				},
+			},
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes a bug where commits with messages that do not strictly conform to
conventional commits spec would be ignored. This could easily happen
while parsing footers like "Closes #xx" which would start the footer
section, while continuing with the body afterwards.

This solution has two downsides:

- these warnings are not surfaced to the user.
- If a `BREAKING CHANGE` footer exists after the parsing issue it is ignored

Thanks to @jooola for the bug report and test case.

Closes #99 #100