### PR TITLE
fix: create CHANGELOG.md if it does not exist

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	remoteName = "origin"
+	remoteName         = "origin"
+	newFilePermissions = 0o644
 )
 
 type Commit struct {
@@ -97,13 +98,18 @@ func (r *Repository) Checkout(_ context.Context, branch string) error {
 	return nil
 }
 
-func (r *Repository) UpdateFile(_ context.Context, path string, updaters []updater.Updater) error {
+func (r *Repository) UpdateFile(_ context.Context, path string, create bool, updaters []updater.Updater) error {
 	worktree, err := r.r.Worktree()
 	if err != nil {
 		return err
 	}
 
-	file, err := worktree.Filesystem.OpenFile(path, os.O_RDWR, 0)
+	fileFlags := os.O_RDWR
+	if create {
+		fileFlags |= os.O_CREATE
+	}
+
+	file, err := worktree.Filesystem.OpenFile(path, fileFlags, newFilePermissions)
 	if err != nil {
 		return err
 	}

--- a/releaserpleaser.go
+++ b/releaserpleaser.go
@@ -253,14 +253,14 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 	// Info for updaters
 	info := updater.ReleaseInfo{Version: nextVersion, ChangelogEntry: changelogEntry}
 
-	err = repo.UpdateFile(ctx, updater.ChangelogFile, updater.WithInfo(info, updater.Changelog))
+	err = repo.UpdateFile(ctx, updater.ChangelogFile, true, updater.WithInfo(info, updater.Changelog))
 	if err != nil {
 		return fmt.Errorf("failed to update changelog file: %w", err)
 	}
 
 	for _, path := range rp.extraFiles {
 		// TODO: Check for missing files
-		err = repo.UpdateFile(ctx, path, updater.WithInfo(info, rp.updaters...))
+		err = repo.UpdateFile(ctx, path, false, updater.WithInfo(info, rp.updaters...))
 		if err != nil {
 			return fmt.Errorf("failed to run file updater: %w", err)
 		}


### PR DESCRIPTION
During a previous refactoring (#15) the Changelog generation logic stopped creating the file if it did not exist. This makes sure that the file actually gets created. This is primarily required while onboarding new repositories.

Closes #85 