### PR TITLE
feat(github): mark pre-releases correctly

### DIFF
--- a/internal/versioning/semver.go
+++ b/internal/versioning/semver.go
@@ -110,3 +110,16 @@ func parseSemverWithDefault(tag *git.Tag) (semver.Version, error) {
 
 	return parsedVersion, nil
 }
+
+func (s semVer) IsPrerelease(version string) bool {
+	semVersion, err := parseSemverWithDefault(&git.Tag{Hash: "", Name: version})
+	if err != nil {
+		return false
+	}
+
+	if len(semVersion.Pre) > 0 {
+		return true
+	}
+
+	return false
+}

--- a/internal/versioning/semver_test.go
+++ b/internal/versioning/semver_test.go
@@ -388,3 +388,37 @@ func TestVersionBumpFromCommits(t *testing.T) {
 		})
 	}
 }
+
+func TestSemVer_IsPrerelease(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		{
+			name:    "empty string",
+			version: "",
+			want:    false,
+		},
+		{
+			name:    "stable version",
+			version: "v1.0.0",
+			want:    false,
+		},
+		{
+			name:    "pre-release version",
+			version: "v1.0.0-rc.1+foo",
+			want:    true,
+		},
+		{
+			name:    "invalid version",
+			version: "ajfkdafjdsfj",
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, SemVer.IsPrerelease(tt.version), "IsSemverPrerelease(%v)", tt.version)
+		})
+	}
+}

--- a/internal/versioning/versioning.go
+++ b/internal/versioning/versioning.go
@@ -8,6 +8,7 @@ import (
 
 type Strategy interface {
 	NextVersion(git.Releases, VersionBump, NextVersionType) (string, error)
+	IsPrerelease(version string) bool
 }
 
 type VersionBump conventionalcommits.VersionBump

--- a/releaserpleaser.go
+++ b/releaserpleaser.go
@@ -122,10 +122,10 @@ func (rp *ReleaserPleaser) createPendingRelease(ctx context.Context, pr *release
 		return err
 	}
 
-	// TODO: pre-release & latest
+	// TODO: Check if version should be marked latest
 
 	logger.DebugContext(ctx, "Creating release on forge")
-	err = rp.forge.CreateRelease(ctx, *pr.ReleaseCommit, version, changelogText, false, true)
+	err = rp.forge.CreateRelease(ctx, *pr.ReleaseCommit, version, changelogText, rp.versioning.IsPrerelease(version), true)
 	if err != nil {
 		return fmt.Errorf("failed to create release on forge: %w", err)
 	}


### PR DESCRIPTION
In theory every forge can support this, but right now only GitHub allows one to define a release as "pre-release".

Closes #45