### PR TITLE
feat: real user as commit author

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -17,6 +17,9 @@ type Forge interface {
 
 	GitAuth() transport.AuthMethod
 
+	// CommitAuthor returns the git author used for the release commit. It should be the user whose token is used to talk to the API.
+	CommitAuthor(context.Context) (git.Author, error)
+
 	// LatestTags returns the last stable tag created on the main branch. If there is a more recent pre-release tag,
 	// that is also returned. If no tag is found, it returns nil.
 	LatestTags(context.Context) (git.Releases, error)

--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -69,6 +69,22 @@ func (g *GitLab) GitAuth() transport.AuthMethod {
 	}
 }
 
+func (g *GitLab) CommitAuthor(ctx context.Context) (git.Author, error) {
+	g.log.DebugContext(ctx, "getting commit author from current token user")
+
+	user, _, err := g.client.Users.CurrentUser(gitlab.WithContext(ctx))
+	if err != nil {
+		return git.Author{}, err
+	}
+
+	// TODO: Return bot when nothing is returned?
+
+	return git.Author{
+		Name:  user.Name,
+		Email: user.Email,
+	}, nil
+}
+
 func (g *GitLab) LatestTags(ctx context.Context) (git.Releases, error) {
 	g.log.DebugContext(ctx, "listing all tags in gitlab repository")
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,46 @@
+package git
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestAuthor_signature(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		author Author
+		want   *object.Signature
+	}{
+		{author: Author{Name: "foo", Email: "bar@example.com"}, want: &object.Signature{Name: "foo", Email: "bar@example.com", When: now}},
+		{author: Author{Name: "bar", Email: "foo@example.com"}, want: &object.Signature{Name: "bar", Email: "foo@example.com", When: now}},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			if got := tt.author.signature(now); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("signature() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAuthor_String(t *testing.T) {
+	tests := []struct {
+		author Author
+		want   string
+	}{
+		{author: Author{Name: "foo", Email: "bar@example.com"}, want: "foo <bar@example.com>"},
+		{author: Author{Name: "bar", Email: "foo@example.com"}, want: "bar <foo@example.com>"},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			if got := tt.author.String(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/releaserpleaser.go
+++ b/releaserpleaser.go
@@ -255,13 +255,18 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 		}
 	}
 
+	releaseCommitAuthor, err := rp.forge.CommitAuthor(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get commit author: %w", err)
+	}
+
 	releaseCommitMessage := fmt.Sprintf("chore(%s): release %s", rp.targetBranch, nextVersion)
-	releaseCommit, err := repo.Commit(ctx, releaseCommitMessage)
+	releaseCommit, err := repo.Commit(ctx, releaseCommitMessage, releaseCommitAuthor)
 	if err != nil {
 		return fmt.Errorf("failed to commit changes: %w", err)
 	}
 
-	logger.InfoContext(ctx, "created release commit", "commit.hash", releaseCommit.Hash, "commit.message", releaseCommit.Message)
+	logger.InfoContext(ctx, "created release commit", "commit.hash", releaseCommit.Hash, "commit.message", releaseCommit.Message, "commit.author", releaseCommitAuthor)
 
 	// Check if anything changed in comparison to the remote branch (if exists)
 	newReleasePRChanges, err := repo.HasChangesWithRemote(ctx, rpBranch)


### PR DESCRIPTION
Previously all commits were authored and committed by `releaser-pleaser <>`. This is weird when looking at the commit. We now check with the Forge API for details on the currently authenticated user, and use that name and email as the commit author. The commit committer stays the same for now.

In GitHub, the default `$GITHUB_TOKEN` does not allow access to the required endpoint, so for github the user `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` is hardcoded when the request fails.