### PR TITLE
feat: run one job concurrently to reduce chance of conflicts

### DIFF
--- a/.github/workflows/releaser-pleaser.yaml
+++ b/.github/workflows/releaser-pleaser.yaml
@@ -10,6 +10,13 @@ on:
       - labeled
       - unlabeled
 
+# Only one job needs to run at a time, if a new job is started there is probably new data to include in the response, so
+# it does not make sense to finish the previous job. This also helps with "data-race conflicts", where a human changes
+# the PR description but releaser-pleaser was already running and overwrites the humans changes.
+concurrency:
+  group: releaser-pleaser
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/docs/tutorials/github.md
+++ b/docs/tutorials/github.md
@@ -44,6 +44,10 @@ on:
       - labeled
       - unlabeled
 
+concurrency:
+  group: releaser-pleaser
+  cancel-in-progress: true
+
 jobs:
   releaser-pleaser:
     runs-on: ubuntu-latest

--- a/templates/run.yml
+++ b/templates/run.yml
@@ -26,9 +26,19 @@ spec:
 releaser-pleaser:
   stage: $[[ inputs.stage ]]
   needs: $[[ inputs.needs ]]
+
   rules:
     # There is no way to run a pipeline when the MR description is updated :(
     - if: $CI_COMMIT_BRANCH == "$[[ inputs.branch ]]"
+
+  # If a newer releaser-pleaser job runs, this one may be cancelled without problem, releaser-pleaser is idempotent.
+  # This only works if the user enables "auto-cancel redundant pipelines", which we do tell them to, because this is
+  # intrusive and up to the user.
+  interruptible: true
+
+  # No need to have multiple releaser-pleaser jobs running at the same time. They all act on the same global state.
+  resource_group: releaser-pleaser
+
   image:
     name: ghcr.io/apricote/releaser-pleaser:v0.5.1 # x-releaser-pleaser-version
     entrypoint: [ "" ]


### PR DESCRIPTION
Each run of releaser-pleaser acts on the same global state in the forge. Therefore, parallel runs are unnecessary.

This commit also communicates to the GitHub and GitLab CI pipelines that the releaser-pleaser jobs can be cancelled as early as possible.

- On GitHub Actions this can be guaranteed through the workflow settings. These settings are copied into each repository that uses releaser-pleaser, so users need to update this manually. I will add a note to the release notes for this.
- On GitLab CI/CD this requires the user to configure a project level setting to "auto-cancel redundant pipelines". We will not recommend user to set this, as it is quite invasive and can break their regular CI pipelines.