### PR TITLE
ci: only build single platform for local releaser-pleaser jobs

### DIFF
--- a/.github/workflows/releaser-pleaser.yaml
+++ b/.github/workflows/releaser-pleaser.yaml
@@ -38,7 +38,7 @@ jobs:
       # Without this, any new flags in `action.yml` would break the job in this repository until the new
       # version is released. But a new version can only be released if this job works.
       - uses: ko-build/setup-ko@d006021bd0c28d1ce33a07e7943d48b079944c8d # v0.9
-      - run: ko build --bare --local --tags ci github.com/apricote/releaser-pleaser/cmd/rp
+      - run: ko build --bare --local --platform linux/amd64 --tags ci github.com/apricote/releaser-pleaser/cmd/rp
 
       - run: mkdir -p .github/actions/releaser-pleaser
       - run: "sed -i 's|image: .*$|image: docker://ghcr.io/apricote/releaser-pleaser:ci|g' action.yml"


### PR DESCRIPTION
The image is never pushed and only executed on linux/amd64 hosts, so building linux/arm64 is a waste of time and resources.