### PR TITLE
fix(gitlab): support Fast-forward merge

### DIFF
--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -193,7 +193,7 @@ func (g *GitLab) prForCommit(ctx context.Context, commit git.Commit) (*git.PullR
 	var mergeRequest *gitlab.BasicMergeRequest
 	for _, mr := range associatedMRs {
 		// We only look for the MR that has this commit set as the "merge/squash commit" => The result of squashing this branch onto main
-		if mr.MergeCommitSHA == commit.Hash || mr.SquashCommitSHA == commit.Hash {
+		if mr.MergeCommitSHA == commit.Hash || mr.SquashCommitSHA == commit.Hash || mr.SHA == commit.Hash {
 			mergeRequest = mr
 			break
 		}
@@ -403,12 +403,14 @@ func gitlabMRToReleasePullRequest(pr *gitlab.BasicMergeRequest) *releasepr.Relea
 		}
 	}
 
-	// Commit SHA is saved in either [MergeCommitSHA] or [SquashCommitSHA] depending on which merge method was used.
+	// Commit SHA is saved in either [MergeCommitSHA], [SquashCommitSHA] or [SHA] depending on which merge method was used.
 	var releaseCommit *git.Commit
 	if pr.MergeCommitSHA != "" {
 		releaseCommit = &git.Commit{Hash: pr.MergeCommitSHA}
 	} else if pr.SquashCommitSHA != "" {
 		releaseCommit = &git.Commit{Hash: pr.SquashCommitSHA}
+	} else if pr.MergedAt != nil && pr.SHA != "" {
+		releaseCommit = &git.Commit{Hash: pr.SHA}
 	}
 
 	return &releasepr.ReleasePullRequest{

--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -405,11 +405,12 @@ func gitlabMRToReleasePullRequest(pr *gitlab.BasicMergeRequest) *releasepr.Relea
 
 	// Commit SHA is saved in either [MergeCommitSHA], [SquashCommitSHA] or [SHA] depending on which merge method was used.
 	var releaseCommit *git.Commit
-	if pr.MergeCommitSHA != "" {
+	switch {
+	case pr.MergeCommitSHA != "":
 		releaseCommit = &git.Commit{Hash: pr.MergeCommitSHA}
-	} else if pr.SquashCommitSHA != "" {
+	case pr.SquashCommitSHA != "":
 		releaseCommit = &git.Commit{Hash: pr.SquashCommitSHA}
-	} else if pr.MergedAt != nil && pr.SHA != "" {
+	case pr.MergedAt != nil && pr.SHA != "":
 		releaseCommit = &git.Commit{Hash: pr.SHA}
 	}
 


### PR DESCRIPTION
This changes allows detecting that the Release Pleaser PR is well merged. 

As of today, it fails with "2025-07-10T15:24:08Z ERR failed to create pending releases: pull request is missing the merge commit".

Failing job: https://gitlab.com/ccl-consulting/fleeting-plugin-scaleway/-/jobs/10639970620
Merged pull request: https://gitlab.com/ccl-consulting/fleeting-plugin-scaleway/-/merge_requests/12 
Merged pull request API view: https://gitlab.com/api/v4/projects/70582087/merge_requests/12
Landed commit: https://gitlab.com/ccl-consulting/fleeting-plugin-scaleway/-/commit/29ac598d0bf7952a85f28ac5cf5d3e113069f7ae