### PR TITLE
feat: highlight breaking changes in release notes

### DIFF
--- a/internal/changelog/changelog.md.tpl
+++ b/internal/changelog/changelog.md.tpl
@@ -1,5 +1,5 @@
 {{define "entry" -}}
-- {{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}}
+- {{ if .BreakingChange}}**BREAKING**: {{end}}{{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}}
 {{ end }}
 
 {{- if not .Formatting.HideVersionTitle }}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -55,6 +55,23 @@ func Test_NewChangelogEntry(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "single breaking change",
+			args: args{
+				analyzedCommits: []commitparser.AnalyzedCommit{
+					{
+						Commit:         git.Commit{},
+						Type:           "feat",
+						Description:    "Foobar!",
+						BreakingChange: true,
+					},
+				},
+				version: "1.0.0",
+				link:    "https://example.com/1.0.0",
+			},
+			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Features\n\n- **BREAKING**: Foobar!\n",
+			wantErr: assert.NoError,
+		},
+		{
 			name: "single fix",
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{


### PR DESCRIPTION
Add a `**BREAKING**` prefix to any entries in the changelog that are marked as breaking changes.

Closes #225