### PR TITLE
fix: filter out empty updaters in input

### DIFF
--- a/cmd/rp/cmd/run.go
+++ b/cmd/rp/cmd/run.go
@@ -135,6 +135,10 @@ func parseUpdaters(input []string) []string {
 	names := []string{"changelog", "generic"}
 
 	for _, u := range input {
+		if u == "" {
+			continue
+		}
+
 		if strings.HasPrefix(u, "-") {
 			name := u[1:]
 			names = slices.DeleteFunc(names, func(existingName string) bool { return existingName == name })

--- a/cmd/rp/cmd/run_test.go
+++ b/cmd/rp/cmd/run_test.go
@@ -89,6 +89,11 @@ func Test_parseUpdaters(t *testing.T) {
 			input: []string{"bar", "bar", "changelog"},
 			want:  []string{"bar", "changelog", "generic"},
 		},
+		{
+			name:  "remove empty entries",
+			input: []string{""},
+			want:  []string{"changelog", "generic"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The default input on GitHub `""` is parsed as an empty string, which does not make sense. We will just filter out any empty strings from the input.