### PR TITLE
refactor(cmd): use factories instead of global cobra command structs

### DIFF
--- a/cmd/rp/main.go
+++ b/cmd/rp/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/apricote/releaser-pleaser/cmd/rp/cmd"
+	_ "github.com/apricote/releaser-pleaser/internal/log"
 )
 
 func main() {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/lmittmann/tint"
+)
+
+func GetLogger(w io.Writer) *slog.Logger {
+	return slog.New(
+		tint.NewHandler(w, &tint.Options{
+			Level:      slog.LevelDebug,
+			TimeFormat: time.RFC3339,
+		}),
+	)
+}
+
+func init() {
+	slog.SetDefault(GetLogger(os.Stderr))
+}


### PR DESCRIPTION
This enables us to create new commands for e2e tests.