### PR TITLE
ci: fix ko settings after using mise

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,4 +18,12 @@ jobs:
 
       - uses: jdx/mise-action@5ac50f778e26fac95da98d50503682459e86d566 # v3
 
+      - name: Prepare ko
+        run: |
+          echo "${{ github.token }}" | ko login ghcr.io --username "dummy" --password-stdin
+
+          repo=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "KO_DOCKER_REPO=ghcr.io/${repo}"
+          echo "KO_DOCKER_REPO=ghcr.io/${repo}" >> $GITHUB_ENV
+
       - run: ko build --bare --tags ${{ github.ref_name }} github.com/apricote/releaser-pleaser/cmd/rp

--- a/.github/workflows/releaser-pleaser.yaml
+++ b/.github/workflows/releaser-pleaser.yaml
@@ -36,8 +36,7 @@ jobs:
       # version is released. But a new version can only be released if this job works.
       - run: ko build --bare --local --platform linux/amd64 --tags ci github.com/apricote/releaser-pleaser/cmd/rp
 
-      - run: mkdir -p .github/actions/releaser-pleaser
-      - run: "sed -i 's|image: .*$|image: docker://ghcr.io/apricote/releaser-pleaser:ci|g' action.yml"
+      - run: "sed -i 's|image: .*$|image: docker://ko.local:ci|g' action.yml"
 
       # Dogfood the action to make sure it works for users.
       - name: releaser-pleaser


### PR DESCRIPTION
The `ko-build/setup-ko` action not only installed ko, but also configured `KO_DOCKER_REPO` and logged in using `ko login`.