### PR TITLE
feat: allow using code blocks within release-notes

### DIFF
--- a/docs/guides/release-notes.md
+++ b/docs/guides/release-notes.md
@@ -43,17 +43,17 @@ The release pull request description has text fields where maintainers can add t
 
 When you edit the description, make sure to put your desired content into the code blocks named `rp-prefix` and `rp-suffix`. Only the content of these blocks is considered.
 
->     ```rp-prefix
+>     ~~~~rp-prefix
 >     ### Prefix
 >
 >     This will be shown as the Prefix.
->     ```
+>     ~~~~
 >
->     ```rp-suffix
+>     ~~~~rp-suffix
 >     ### Suffix
 >
 >     This will be shown as the Suffix.
->     ```
+>     ~~~~
 
 To match the style of the auto-generated release notes, you should start any headings at level 3 (`### Title`).
 

--- a/docs/reference/pr-options.md
+++ b/docs/reference/pr-options.md
@@ -30,17 +30,17 @@ Any text in code blocks with these languages is being added to the start or end 
 
 **Examples**:
 
-    ```rp-prefix
+    ~~~~rp-prefix
     #### Awesome new feature!
 
     This text is at the start of the release notes.
-    ```
+    ~~~~
 
-    ```rp-suffix
+    ~~~~rp-suffix
     #### Version Compatibility
 
     And this at the end.
-    ```
+    ~~~~
 
 ### Status
 

--- a/internal/releasepr/releasepr_test.go
+++ b/internal/releasepr/releasepr_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/apricote/releaser-pleaser/internal/git"
+	"github.com/apricote/releaser-pleaser/internal/testdata"
 	"github.com/apricote/releaser-pleaser/internal/versioning"
 )
 
@@ -37,20 +38,24 @@ func TestReleasePullRequest_GetOverrides(t *testing.T) {
 			name: "prefix in description",
 			pr: ReleasePullRequest{
 				PullRequest: git.PullRequest{
-					Description: "```rp-prefix\n## Foo\n\n- Cool thing\n```",
+					Description: testdata.MustReadFileString(t, "description-prefix.txt"),
 				},
 			},
-			want:    ReleaseOverrides{Prefix: "## Foo\n\n- Cool thing"},
+			want: ReleaseOverrides{
+				Prefix: testdata.MustReadFileString(t, "prefix.txt"),
+			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "suffix in description",
 			pr: ReleasePullRequest{
 				PullRequest: git.PullRequest{
-					Description: "```rp-suffix\n## Compatibility\n\nNo compatibility guarantees.\n```",
+					Description: testdata.MustReadFileString(t, "description-suffix.txt"),
 				},
 			},
-			want:    ReleaseOverrides{Suffix: "## Compatibility\n\nNo compatibility guarantees."},
+			want: ReleaseOverrides{
+				Suffix: testdata.MustReadFileString(t, "suffix.txt"),
+			},
 			wantErr: assert.NoError,
 		},
 	}
@@ -80,30 +85,10 @@ func TestReleasePullRequest_ChangelogText(t *testing.T) {
 			wantErr:     assert.NoError,
 		},
 		{
-			name: "with section",
-			description: `# Foobar
-
-<!-- section-start changelog -->
-This is the changelog
-
-## Awesome
-
-### New
-
-#### Changes
-<!-- section-end changelog -->
-
-Suffix Things
-`,
-			want: `This is the changelog
-
-## Awesome
-
-### New
-
-#### Changes
-`,
-			wantErr: assert.NoError,
+			name:        "with section",
+			description: testdata.MustReadFileString(t, "changelog.txt"),
+			want:        testdata.MustReadFileString(t, "changelog-content.txt"),
+			wantErr:     assert.NoError,
 		},
 	}
 	for _, tt := range tests {
@@ -178,75 +163,17 @@ func TestReleasePullRequest_SetDescription(t *testing.T) {
 			name:           "no overrides",
 			changelogEntry: `## v1.0.0`,
 			overrides:      ReleaseOverrides{},
-			want: `<!-- section-start changelog -->
-## v1.0.0
-<!-- section-end changelog -->
-
----
-
-<details>
-  <summary><h4>PR by <a href="https://github.com/apricote/releaser-pleaser">releaser-pleaser</a> 🤖</h4></summary>
-
-If you want to modify the proposed release, add you overrides here. You can learn more about the options in the docs.
-
-## Release Notes
-
-### Prefix / Start
-
-This will be added to the start of the release notes.
-
-` + "```" + `rp-prefix
-` + "```" + `
-
-### Suffix / End
-
-This will be added to the end of the release notes.
-
-` + "```" + `rp-suffix
-` + "```" + `
-
-</details>
-`,
-			wantErr: assert.NoError,
+			want:           testdata.MustReadFileString(t, "description-no-overrides.txt"),
+			wantErr:        assert.NoError,
 		},
 		{
 			name:           "existing overrides",
 			changelogEntry: `## v1.0.0`,
 			overrides: ReleaseOverrides{
-				Prefix: "This release is awesome!",
-				Suffix: "Fooo",
+				Prefix: testdata.MustReadFileString(t, "prefix.txt"),
+				Suffix: testdata.MustReadFileString(t, "suffix.txt"),
 			},
-			want: `<!-- section-start changelog -->
-## v1.0.0
-<!-- section-end changelog -->
-
----
-
-<details>
-  <summary><h4>PR by <a href="https://github.com/apricote/releaser-pleaser">releaser-pleaser</a> 🤖</h4></summary>
-
-If you want to modify the proposed release, add you overrides here. You can learn more about the options in the docs.
-
-## Release Notes
-
-### Prefix / Start
-
-This will be added to the start of the release notes.
-
-` + "```" + `rp-prefix
-This release is awesome!
-` + "```" + `
-
-### Suffix / End
-
-This will be added to the end of the release notes.
-
-` + "```" + `rp-suffix
-Fooo
-` + "```" + `
-
-</details>
-`,
+			want:    testdata.MustReadFileString(t, "description-overrides.txt"),
 			wantErr: assert.NoError,
 		},
 	}

--- a/internal/testdata/changelog-content.txt
+++ b/internal/testdata/changelog-content.txt
@@ -1,0 +1,7 @@
+This is the changelog
+
+## Awesome
+
+### New
+
+#### Changes

--- a/internal/testdata/changelog.txt
+++ b/internal/testdata/changelog.txt
@@ -1,0 +1,13 @@
+# Foobar
+
+<!-- section-start changelog -->
+This is the changelog
+
+## Awesome
+
+### New
+
+#### Changes
+<!-- section-end changelog -->
+
+Suffix Things

--- a/internal/testdata/description-no-overrides.txt
+++ b/internal/testdata/description-no-overrides.txt
@@ -1,5 +1,5 @@
 <!-- section-start changelog -->
-{{ .Changelog }}
+## v1.0.0
 <!-- section-end changelog -->
 
 ---
@@ -16,8 +16,6 @@ If you want to modify the proposed release, add you overrides here. You can lear
 This will be added to the start of the release notes.
 
 ~~~~rp-prefix
-{{- if .Overrides.Prefix }}
-{{ .Overrides.Prefix }}{{ end }}
 ~~~~
 
 ### Suffix / End
@@ -25,8 +23,6 @@ This will be added to the start of the release notes.
 This will be added to the end of the release notes.
 
 ~~~~rp-suffix
-{{- if .Overrides.Suffix }}
-{{ .Overrides.Suffix }}{{ end }}
 ~~~~
 
 </details>

--- a/internal/testdata/description-overrides.txt
+++ b/internal/testdata/description-overrides.txt
@@ -1,5 +1,5 @@
 <!-- section-start changelog -->
-{{ .Changelog }}
+## v1.0.0
 <!-- section-end changelog -->
 
 ---
@@ -16,8 +16,19 @@ If you want to modify the proposed release, add you overrides here. You can lear
 This will be added to the start of the release notes.
 
 ~~~~rp-prefix
-{{- if .Overrides.Prefix }}
-{{ .Overrides.Prefix }}{{ end }}
+## Foo
+
+- Cool thing
+
+```go
+// Some code example
+func IsPositive(number int) error {
+	if number < 0 {
+		return fmt.Errorf("number %d is negative", number)
+	}
+	return nil
+}
+```
 ~~~~
 
 ### Suffix / End
@@ -25,8 +36,9 @@ This will be added to the start of the release notes.
 This will be added to the end of the release notes.
 
 ~~~~rp-suffix
-{{- if .Overrides.Suffix }}
-{{ .Overrides.Suffix }}{{ end }}
+## Compatibility
+
+No compatibility guarantees.
 ~~~~
 
 </details>

--- a/internal/testdata/description-prefix.txt
+++ b/internal/testdata/description-prefix.txt
@@ -1,5 +1,5 @@
 <!-- section-start changelog -->
-{{ .Changelog }}
+## v1.0.0
 <!-- section-end changelog -->
 
 ---
@@ -16,8 +16,19 @@ If you want to modify the proposed release, add you overrides here. You can lear
 This will be added to the start of the release notes.
 
 ~~~~rp-prefix
-{{- if .Overrides.Prefix }}
-{{ .Overrides.Prefix }}{{ end }}
+## Foo
+
+- Cool thing
+
+```go
+// Some code example
+func IsPositive(number int) error {
+	if number < 0 {
+		return fmt.Errorf("number %d is negative", number)
+	}
+	return nil
+}
+```
 ~~~~
 
 ### Suffix / End
@@ -25,8 +36,6 @@ This will be added to the start of the release notes.
 This will be added to the end of the release notes.
 
 ~~~~rp-suffix
-{{- if .Overrides.Suffix }}
-{{ .Overrides.Suffix }}{{ end }}
 ~~~~
 
 </details>

--- a/internal/testdata/description-suffix.txt
+++ b/internal/testdata/description-suffix.txt
@@ -1,5 +1,5 @@
 <!-- section-start changelog -->
-{{ .Changelog }}
+## v1.0.0
 <!-- section-end changelog -->
 
 ---
@@ -16,8 +16,6 @@ If you want to modify the proposed release, add you overrides here. You can lear
 This will be added to the start of the release notes.
 
 ~~~~rp-prefix
-{{- if .Overrides.Prefix }}
-{{ .Overrides.Prefix }}{{ end }}
 ~~~~
 
 ### Suffix / End
@@ -25,8 +23,9 @@ This will be added to the start of the release notes.
 This will be added to the end of the release notes.
 
 ~~~~rp-suffix
-{{- if .Overrides.Suffix }}
-{{ .Overrides.Suffix }}{{ end }}
+## Compatibility
+
+No compatibility guarantees.
 ~~~~
 
 </details>

--- a/internal/testdata/prefix.txt
+++ b/internal/testdata/prefix.txt
@@ -1,0 +1,13 @@
+## Foo
+
+- Cool thing
+
+```go
+// Some code example
+func IsPositive(number int) error {
+	if number < 0 {
+		return fmt.Errorf("number %d is negative", number)
+	}
+	return nil
+}
+```

--- a/internal/testdata/suffix.txt
+++ b/internal/testdata/suffix.txt
@@ -1,0 +1,3 @@
+## Compatibility
+
+No compatibility guarantees.

--- a/internal/testdata/testdata.go
+++ b/internal/testdata/testdata.go
@@ -1,0 +1,19 @@
+package testdata
+
+import (
+	"embed"
+	"testing"
+)
+
+//go:embed *.txt
+var testdata embed.FS
+
+func MustReadFileString(t *testing.T, name string) string {
+	t.Helper()
+
+	content, err := testdata.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(content)
+}


### PR DESCRIPTION
Change the code blocks fences to 4 tildes for the release note prefix and suffix, to allow users to embed their own code blocks using back ticks.

Tildes as code block fences are supported by GFM: https://github.github.com/gfm/#fenced-code-blocks