### PR TITLE
fix: no html escaping for changelog template

### DIFF
--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -3,9 +3,9 @@ package changelog
 import (
 	"bytes"
 	_ "embed"
-	"html/template"
 	"log"
 	"log/slog"
+	"text/template"
 
 	"github.com/apricote/releaser-pleaser/internal/commitparser"
 	"github.com/apricote/releaser-pleaser/internal/markdown"

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/apricote/releaser-pleaser/internal/commitparser"
 	"github.com/apricote/releaser-pleaser/internal/git"
+	"github.com/apricote/releaser-pleaser/internal/testdata"
 )
 
 func ptr[T any](input T) *T {
@@ -143,16 +144,9 @@ func Test_NewChangelogEntry(t *testing.T) {
 				},
 				version: "1.0.0",
 				link:    "https://example.com/1.0.0",
-				prefix:  "### Breaking Changes",
+				prefix:  testdata.MustReadFileString(t, "prefix.txt"),
 			},
-			want: `## [1.0.0](https://example.com/1.0.0)
-
-### Breaking Changes
-
-### Bug Fixes
-
-- Foobar!
-`,
+			want:    testdata.MustReadFileString(t, "changelog-entry-prefix.txt"),
 			wantErr: assert.NoError,
 		},
 		{
@@ -167,18 +161,9 @@ func Test_NewChangelogEntry(t *testing.T) {
 				},
 				version: "1.0.0",
 				link:    "https://example.com/1.0.0",
-				suffix:  "### Compatibility\n\nThis version is compatible with flux-compensator v2.2 - v2.9.",
+				suffix:  testdata.MustReadFileString(t, "suffix.txt"),
 			},
-			want: `## [1.0.0](https://example.com/1.0.0)
-
-### Bug Fixes
-
-- Foobar!
-
-### Compatibility
-
-This version is compatible with flux-compensator v2.2 - v2.9.
-`,
+			want:    testdata.MustReadFileString(t, "changelog-entry-suffix.txt"),
 			wantErr: assert.NoError,
 		},
 	}

--- a/internal/testdata/changelog-entry-prefix.txt
+++ b/internal/testdata/changelog-entry-prefix.txt
@@ -1,0 +1,19 @@
+## [1.0.0](https://example.com/1.0.0)
+
+## Foo
+
+- Cool thing
+
+```go
+// Some code example
+func IsPositive(number int) error {
+	if number < 0 {
+		return fmt.Errorf("number %d is negative", number)
+	}
+	return nil
+}
+```
+
+### Bug Fixes
+
+- Foobar!

--- a/internal/testdata/changelog-entry-suffix.txt
+++ b/internal/testdata/changelog-entry-suffix.txt
@@ -1,0 +1,9 @@
+## [1.0.0](https://example.com/1.0.0)
+
+### Bug Fixes
+
+- Foobar!
+
+## Compatibility
+
+This version is compatible with flux-compensator v2.2 - v2.9.

--- a/internal/testdata/description-overrides.txt
+++ b/internal/testdata/description-overrides.txt
@@ -38,7 +38,7 @@ This will be added to the end of the release notes.
 ~~~~rp-suffix
 ## Compatibility
 
-No compatibility guarantees.
+This version is compatible with flux-compensator v2.2 - v2.9.
 ~~~~
 
 </details>

--- a/internal/testdata/description-suffix.txt
+++ b/internal/testdata/description-suffix.txt
@@ -25,7 +25,7 @@ This will be added to the end of the release notes.
 ~~~~rp-suffix
 ## Compatibility
 
-No compatibility guarantees.
+This version is compatible with flux-compensator v2.2 - v2.9.
 ~~~~
 
 </details>

--- a/internal/testdata/suffix.txt
+++ b/internal/testdata/suffix.txt
@@ -1,3 +1,3 @@
 ## Compatibility
 
-No compatibility guarantees.
+This version is compatible with flux-compensator v2.2 - v2.9.


### PR DESCRIPTION
Do not html escape the content of the changelog.

Closes #276 

