### PR TITLE
feat(updater): add helmchart

### DIFF
--- a/cmd/rp/cmd/run.go
+++ b/cmd/rp/cmd/run.go
@@ -104,6 +104,8 @@ func newRunCommand() *cobra.Command {
 					updaters = append(updaters, updater.Changelog())
 				case "packagejson":
 					updaters = append(updaters, updater.PackageJson())
+				case "helmchart":
+					updaters = append(updaters, updater.HelmChart())
 				default:
 					return fmt.Errorf("unknown updater: %s", name)
 				}

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -57,5 +57,6 @@ Learn more in the [Release Notes customization](../guides/release-notes.md) guid
 ### Updater
 
 Updaters can update or create files that will be included in [Release Pull Request](#release-pull-request). Examples of Updaters are
-`changelog` for `CHANGELOG.md`, `generic` that can update arbitrary files and
-`packagejson` that knows how to update Node.JS `package.json` files.
+`changelog` for `CHANGELOG.md`, `generic` that can update arbitrary files,
+`packagejson` that knows how to update Node.JS `package.json` files and
+`helmchart` for Helm's `Chart.yaml` file.

--- a/docs/reference/updaters.md
+++ b/docs/reference/updaters.md
@@ -31,3 +31,10 @@ Learn more about this updater in ["Updating arbitrary files"](../guides/updating
 - **Default**: disabled
 
 This updater can update the `version` field in Node.js `package.json` files. The updater is disabled by default.
+
+## Helm's `Chart.yaml` Updater
+
+- **Name**: `helmchart`
+- **Default**: disabled
+
+This updater can update the `version` field in Helm's `Chart.yaml` files. The updater is disabled by default.

--- a/internal/updater/helmchart.go
+++ b/internal/updater/helmchart.go
@@ -1,0 +1,35 @@
+package updater
+
+import (
+	"regexp"
+)
+
+// HelmChart creates an updater that modifies the version field in Chart.yaml files
+func HelmChart() Updater {
+	return helmchart{}
+}
+
+type helmchart struct{}
+
+func (h helmchart) Files() []string {
+	return []string{"Chart.yaml"}
+}
+
+func (h helmchart) CreateNewFiles() bool {
+	return false
+}
+
+func (h helmchart) Update(info ReleaseInfo) func(content string) (string, error) {
+	return func(content string) (string, error) {
+		// Regex to match ^version: ...$ with flexible whitespace in multiline mode
+		versionRegex := regexp.MustCompile(`(?m:^(version:\s*)\S*$)`)
+
+		// Check if the file contains a version field
+		if !versionRegex.MatchString(content) {
+			return content, nil
+		}
+
+		// Replace the version value while preserving the original formatting
+		return versionRegex.ReplaceAllString(content, `${1}`+info.Version), nil
+	}
+}

--- a/internal/updater/helmchart_test.go
+++ b/internal/updater/helmchart_test.go
@@ -1,0 +1,62 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHelmChartUpdater_Files(t *testing.T) {
+	assert.Equal(t, []string{"Chart.yaml"}, HelmChart().Files())
+}
+
+func TestHelmChartUpdater_CreateNewFiles(t *testing.T) {
+	assert.False(t, HelmChart().CreateNewFiles())
+}
+
+func TestHelmChartUpdater_Update(t *testing.T) {
+	tests := []updaterTestCase{
+		{
+			name:    "simple Chart.yaml",
+			content: "apiVersion: v2\nname: test\nversion: v1.0.0",
+			info: ReleaseInfo{
+				Version: "v2.0.5",
+			},
+			want:    "apiVersion: v2\nname: test\nversion: v2.0.5",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "complex Chart.yaml",
+			content: "apiVersion: v2\nname: test\ndescription: testing version update against complex Chart.yaml\ntype: application\nkeywords:\n  - testing\n  - version\n  - update\nversion: 1.0.0\nhome: https://apricote.github.io/releaser-pleaser/\ndependencies:\n  - name: somechart\n    version: 1.2.3\n",
+			info: ReleaseInfo{
+				Version: "v2.0.0",
+			},
+			want:    "apiVersion: v2\nname: test\ndescription: testing version update against complex Chart.yaml\ntype: application\nkeywords:\n  - testing\n  - version\n  - update\nversion: v2.0.0\nhome: https://apricote.github.io/releaser-pleaser/\ndependencies:\n  - name: somechart\n    version: 1.2.3\n",
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "invalid yaml",
+			content: `not yaml`,
+			info: ReleaseInfo{
+				Version: "v2.0.0",
+			},
+			want:    `not yaml`,
+			wantErr: assert.NoError,
+		},
+		{
+			name:    "yaml without version",
+			content: `apiVersion: v2\nname: test`,
+			info: ReleaseInfo{
+				Version: "v2.0.0",
+			},
+			want:    `apiVersion: v2\nname: test`,
+			wantErr: assert.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runUpdaterTest(t, HelmChart(), tt)
+		})
+	}
+}


### PR DESCRIPTION
Nice tool you got there :)
A little PR to add a `HelmChart` Updater that supports Helm's `Chart.yaml` file.

Files where shamelessly copied from the `PackageJson` Updater and modified. Hope I did not miss any search&replaces.

Insights into requirements for the `Chart.yaml` version field can be found here:
https://helm.sh/docs/topics/charts#charts-and-versioning

It supports both notations (with `v` and without), so I keep in during the update.

Greetings