### PR TITLE
feat: make forge configurable in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,22 @@ inputs:
     description: "List of updaters that are run. Default updaters can be removed by specifying them as -name. Multiple updaters should be concatenated with a comma. Default Updaters: changelog,generic"
     required: false
     default: ""
+  forge:
+    description: "Forge this action is run against"
+    required: false
+    default: "github"
+  api-url:
+    description: "API URL of the selected forge "
+    required: false
+    default: ""
+  owner:
+    description: "Owner of the repository"
+    required: false
+    default: ""
+  repo:
+    description: "Name of the repository"
+    required: false
+    default: ""
   # Remember to update docs/reference/github-action.md
 outputs: { }
 runs:
@@ -28,10 +44,14 @@ runs:
   image: docker://ghcr.io/apricote/releaser-pleaser:v0.7.1 # x-releaser-pleaser-version
   args:
     - run
-    - --forge=github
+    - --forge=${{ inputs.forge }}
     - --branch=${{ inputs.branch }}
     - --extra-files="${{ inputs.extra-files }}"
     - --updaters="${{ inputs.updaters }}"
+    - --api-url=${{ inputs.api-url }}
+    - --api-token=${{ inputs.token }}
+    - --owner=${{ inputs.owner }}
+    - --repo=${{ inputs.repo }}
   env:
     GITHUB_TOKEN: "${{ inputs.token }}"
     GITHUB_USER: "oauth2"

--- a/cmd/rp/cmd/run.go
+++ b/cmd/rp/cmd/run.go
@@ -33,7 +33,7 @@ func newRunCommand() *cobra.Command {
 		flagUsername string
 	)
 
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use: "run",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()

--- a/docs/reference/github-action.md
+++ b/docs/reference/github-action.md
@@ -17,11 +17,15 @@ The action does not support floating tags (e.g.
 The following inputs are supported by the `apricote/releaser-pleaser` GitHub Action.
 
 | Input         | Description                                                                                                                                                                            |         Default |                                                              Example |
-|---------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------:|---------------------------------------------------------------------:|
+| ------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------: | -------------------------------------------------------------------: |
 | `branch`      | This branch is used as the target for releases.                                                                                                                                        |          `main` |                                                             `master` |
 | `token`       | GitHub token for creating and updating release PRs                                                                                                                                     | `$GITHUB_TOKEN` |                                `${{secrets.RELEASER_PLEASER_TOKEN}}` |
+| `forge`       | Forge this action is run against                                                                                                                                                       |        `github` |                                                            `forgejo` |
 | `extra-files` | List of files that are scanned for version references by the generic updater.                                                                                                          |            `""` | <pre><code>version/version.go<br>deploy/deployment.yaml</code></pre> |
 | `updaters`    | List of updaters that are run. Default updaters can be removed by specifying them as -name. Multiple updaters should be concatenated with a comma. Default Updaters: changelog,generic |            `""` |                                               `-generic,packagejson` |
+| `api-url`     | API URL of the forge this action is run against.                                                                                                                                       |            `""` |                                        `https://forgejo.example.com` |
+| `owner`       | Owner of the repository. Only required for Forgejo Actions.                                                                                                                            |            `""` |                                                           `apricote` |
+| `repo`        | Name of the repository. Only required for Forgejo Actions.                                                                                                                             |            `""` |                                                   `releaser-pleaser` |
 
 ## Outputs
 


### PR DESCRIPTION
Hi @apricote,

I tried to setup `releaser-pleaser` on my personal Forgejo instance using Forgejo Actions. The `releaser-pleaser` GitHub Action is usable on Forgejo as well. To make it work I had to change it a little and pass a few additional inputs down to the `releaser-pleaser` binary.

Changes made:

- Introduce a `forge` input and pass it as the value of the `--forge` flag.
- Introduce `api-url` input and pass it as the value of the `--api-url` flag. This is required to configure the API URL of the forge. If the action is used with GitHub Actions it is simply ignored.
- Pass `inputs.token` as value to the `--api-token` flag. This is required as the forgejo client does not respect the `GITHUB_ACTION` environment variable.
- Introduce `owner` input and pass it as the value of the `--owner` flag. As this was not passed before the default is set to `""`. In theory it could be set to the value of `github.repository_owner`.
- Introduce `user` input and pass it as the value of the `--user` flag. As this was not passed before the default is set to `""`. GitHub Actions does not seem to provide a convenient way to get the repository without the owner. As such keeping it at `""` for the default is safest.