### PR TITLE
chore: forgejo-sdk pr was merged upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.26.0
 
 require (
-	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2 v2.2.0
+	codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2 v2.2.1-0.20260217203524-edf26081b649
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.17.0
@@ -55,5 +55,3 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2 => codeberg.org/apricote/forgejo-sdk/forgejo/v2 v2.1.2-0.20250615152743-47d3f0434561

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-codeberg.org/apricote/forgejo-sdk/forgejo/v2 v2.1.2-0.20250615152743-47d3f0434561 h1:ZFGmrGQ7cd2mbSLrfjrj3COwPKFfKM6sDO/IsrGDW7w=
-codeberg.org/apricote/forgejo-sdk/forgejo/v2 v2.1.2-0.20250615152743-47d3f0434561/go.mod h1:2i9GsyawlJtVMO5pTS/Om5uo2O3JN/eCjGWy5v15NGg=
+codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2 v2.2.1-0.20260217203524-edf26081b649 h1:y7LJRCaWiAQ61b+3djxTXfPBa9gQC7YDna0Ws9fnadY=
+codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2 v2.2.1-0.20260217203524-edf26081b649/go.mod h1:as/trFjyF7OtQO6/HyYY9+ur8CzWRtlXs9e/xOogCjo=
 dario.cat/mergo v1.0.1 h1:Ra4+bf83h2ztPIQYNP99R6m+Y7KfnARDfID+a+vLl4s=
 dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/42wim/httpsig v1.2.3 h1:xb0YyWhkYj57SPtfSttIobJUPJZB9as1nsfo7KWVcEs=

--- a/internal/forge/forgejo/forgejo.go
+++ b/internal/forge/forgejo/forgejo.go
@@ -294,7 +294,7 @@ func (f *Forgejo) UpdatePullRequest(_ context.Context, pr *releasepr.ReleasePull
 		f.options.Owner, f.options.Repo,
 		int64(pr.ID), forgejo.EditPullRequestOption{
 			Title: pr.Title,
-			Body:  pr.Description,
+			Body:  &pr.Description,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
My PR was merged: https://codeberg.org/mvdkleijn/forgejo-sdk/pulls/79

So the `replace` is no longer necessary and releaser-pleaser can depend on `main` branch directly.