### PR TITLE
test(e2e): verify simple releases

### DIFF
--- a/test/e2e/forge.go
+++ b/test/e2e/forge.go
@@ -3,11 +3,21 @@ package e2e
 import (
 	"context"
 	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport"
+
+	"github.com/apricote/releaser-pleaser/internal/git"
 )
 
 type TestForge interface {
 	Init(ctx context.Context, runID string) error
 	CreateRepo(t *testing.T, opts CreateRepoOpts) (*Repository, error)
+	CloneURL(t *testing.T, repo *Repository) string
+	GitAuth(t *testing.T) transport.AuthMethod
+
+	ListOpenPRs(t *testing.T, repo *Repository) ([]*git.PullRequest, error)
+	MergePR(t *testing.T, repo *Repository, pr *git.PullRequest) error
+	ListTags(t *testing.T, repo *Repository) ([]*git.Tag, error)
 
 	RunArguments() []string
 }

--- a/test/e2e/forgejo/forge.go
+++ b/test/e2e/forgejo/forge.go
@@ -9,7 +9,11 @@ import (
 	"testing"
 
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/require"
 
+	"github.com/apricote/releaser-pleaser/internal/git"
 	"github.com/apricote/releaser-pleaser/test/e2e"
 )
 
@@ -103,11 +107,87 @@ func (f *TestForge) CreateRepo(t *testing.T, opts e2e.CreateRepoOpts) (*e2e.Repo
 	}, nil
 }
 
+func (f *TestForge) CloneURL(t *testing.T, repo *e2e.Repository) string {
+	t.Helper()
+
+	return fmt.Sprintf("%s/%s/%s.git", TestAPIURL, f.username, repo.Name)
+}
+
+func (f *TestForge) GitAuth(t *testing.T) transport.AuthMethod {
+	t.Helper()
+
+	return &http.BasicAuth{
+		Username: f.username,
+		Password: f.token,
+	}
+}
+
+func (f *TestForge) ListOpenPRs(t *testing.T, repo *e2e.Repository) ([]*git.PullRequest, error) {
+	t.Helper()
+
+	fPRs, _, err := f.client.ListRepoPullRequests(f.username, repo.Name, forgejo.ListPullRequestsOptions{
+		State: forgejo.StateOpen,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	prs := make([]*git.PullRequest, 0, len(fPRs))
+	for _, pr := range fPRs {
+		prs = append(prs, forgejoPRToPullRequest(pr))
+	}
+
+	return prs, nil
+}
+
+func (f *TestForge) MergePR(t *testing.T, repo *e2e.Repository, pr *git.PullRequest) error {
+	t.Helper()
+
+	ok, _, err := f.client.MergePullRequest(f.username, repo.Name, pr.ID, forgejo.MergePullRequestOption{Style: forgejo.MergeStyleSquash})
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("merging pull request #%d failed", pr.ID)
+	}
+
+	return nil
+}
+
+func (f *TestForge) ListTags(t *testing.T, repo *e2e.Repository) ([]*git.Tag, error) {
+	t.Helper()
+
+	fTags, _, err := f.client.ListRepoTags(f.username, repo.Name, forgejo.ListRepoTagsOptions{})
+	require.NoError(t, err)
+
+	tags := make([]*git.Tag, 0, len(fTags))
+	for _, tag := range fTags {
+		tags = append(tags, forgejoTagToTag(tag))
+	}
+
+	return tags, nil
+}
+
 func (f *TestForge) RunArguments() []string {
 	return []string{"--forge=forgejo",
 		fmt.Sprintf("--owner=%s", f.username),
 		fmt.Sprintf("--api-url=%s", TestAPIURL),
 		fmt.Sprintf("--api-token=%s", f.token),
 		fmt.Sprintf("--username=%s", f.username),
+	}
+}
+
+func forgejoPRToPullRequest(pr *forgejo.PullRequest) *git.PullRequest {
+	return &git.PullRequest{
+		ID:          pr.Index,
+		Title:       pr.Title,
+		Description: pr.Body,
+	}
+}
+
+func forgejoTagToTag(tag *forgejo.Tag) *git.Tag {
+	return &git.Tag{
+		Hash: tag.Commit.SHA,
+		Name: tag.Name,
 	}
 }

--- a/test/e2e/forgejo/forgejo_test.go
+++ b/test/e2e/forgejo/forgejo_test.go
@@ -10,11 +10,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/apricote/releaser-pleaser/internal/git"
 	"github.com/apricote/releaser-pleaser/test/e2e"
 )
 
 var (
 	f *e2e.Framework
+)
+
+var (
+	TestAuthor = git.Author{
+		Name:  "Peter Parker",
+		Email: "parker@example.com",
+	}
 )
 
 func TestMain(m *testing.M) {
@@ -33,7 +41,56 @@ func TestCreateRepository(t *testing.T) {
 	_ = f.NewRepository(t, t.Name())
 }
 
-func TestRun(t *testing.T) {
+func TestEmptyRun(t *testing.T) {
 	repo := f.NewRepository(t, t.Name())
 	require.NoError(t, f.Run(t, repo, []string{}))
+}
+
+func TestRunMultipleSimpleReleases(t *testing.T) {
+	repo := f.NewRepository(t, t.Name())
+
+	// First release
+	{
+		clonedRepo := f.CloneRepo(t, repo)
+
+		clonedRepo.UpdateFile(t.Context(), "README.md", true, func(_ string) (string, error) {
+			return "# Hello World", nil
+		})
+
+		_, err := clonedRepo.Commit(t.Context(), "feat: cool new thing", TestAuthor)
+		require.NoError(t, err)
+
+		clonedRepo.ForcePush(t.Context(), e2e.TestDefaultBranch)
+
+		require.NoError(t, f.Run(t, repo, []string{}))
+
+		pr := f.HasReleasePR(t, repo, "v0.1.0")
+		f.MergeReleasePR(t, repo, pr)
+
+		require.NoError(t, f.Run(t, repo, []string{}))
+		f.HasTag(t, repo, "v0.1.0")
+	}
+
+	// Second release
+	{
+		clonedRepo := f.CloneRepo(t, repo)
+
+		clonedRepo.UpdateFile(t.Context(), "README.md", true, func(_ string) (string, error) {
+			return "# Goodbye", nil
+		})
+
+		_, err := clonedRepo.Commit(t.Context(), "fix: readme was broken", TestAuthor)
+		require.NoError(t, err)
+
+		clonedRepo.ForcePush(t.Context(), e2e.TestDefaultBranch)
+
+		require.NoError(t, f.Run(t, repo, []string{}))
+
+		pr := f.HasReleasePR(t, repo, "v0.1.1")
+		f.MergeReleasePR(t, repo, pr)
+
+		require.NoError(t, f.Run(t, repo, []string{}))
+		f.HasTag(t, repo, "v0.1.1")
+	}
+
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -6,12 +6,16 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
+	"os"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/apricote/releaser-pleaser/cmd/rp/cmd"
+	"github.com/apricote/releaser-pleaser/internal/git"
 )
 
 const (
@@ -27,14 +31,16 @@ func randomString() string {
 }
 
 type Framework struct {
-	runID string
-	forge TestForge
+	runID  string
+	forge  TestForge
+	logger *slog.Logger
 }
 
 func NewFramework(ctx context.Context, forge TestForge) (*Framework, error) {
 	f := &Framework{
-		runID: randomString(),
-		forge: forge,
+		runID:  randomString(),
+		forge:  forge,
+		logger: slog.New(slog.NewTextHandler(os.Stderr, nil)),
 	}
 
 	err := forge.Init(ctx, f.runID)
@@ -67,6 +73,17 @@ func (f *Framework) NewRepository(t *testing.T, name string) *Repository {
 	return r
 }
 
+func (f *Framework) CloneRepo(t *testing.T, r *Repository) *git.Repository {
+	// TODO: Is this too low-level?
+	t.Helper()
+
+	repo, err := git.CloneRepo(t.Context(), f.logger, f.forge.CloneURL(t, r), TestDefaultBranch, f.forge.GitAuth(t))
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+
+	return repo
+}
+
 func (f *Framework) Run(t *testing.T, r *Repository, extraFiles []string) error {
 	t.Helper()
 
@@ -89,8 +106,48 @@ func (f *Framework) Run(t *testing.T, r *Repository, extraFiles []string) error 
 	stdoutString := stdout.String()
 	stderrString := stderr.String()
 
-	t.Log(stdoutString)
-	t.Log(stderrString)
+	if stdoutString != "" {
+		t.Log("STDOUT: \n", stdoutString)
+	}
+	if stderrString != "" {
+		t.Log("STDERR: \n", stderrString)
+	}
 
 	return err
+}
+
+func (f *Framework) HasReleasePR(t *testing.T, r *Repository, version string) *git.PullRequest {
+	t.Helper()
+
+	prs, err := f.forge.ListOpenPRs(t, r)
+	require.NoError(t, err)
+
+	expectedTitle := fmt.Sprintf("chore(main): release %s", version)
+	index := slices.IndexFunc(prs, func(pr *git.PullRequest) bool {
+		return pr.Title == expectedTitle
+	})
+	require.GreaterOrEqualf(t, index, 0, "release pull request for version %q does not exist", version)
+
+	return prs[index]
+}
+
+func (f *Framework) MergeReleasePR(t *testing.T, r *Repository, pr *git.PullRequest) {
+	t.Helper()
+
+	err := f.forge.MergePR(t, r, pr)
+	require.NoError(t, err)
+}
+
+func (f *Framework) HasTag(t *testing.T, r *Repository, version string) (tag *git.Tag) {
+	t.Helper()
+
+	tags, err := f.forge.ListTags(t, r)
+	require.NoError(t, err)
+
+	index := slices.IndexFunc(tags, func(tag *git.Tag) bool {
+		return tag.Name == version
+	})
+	require.GreaterOrEqualf(t, index, 0, "tag %q does not exist", version)
+
+	return tags[index]
 }


### PR DESCRIPTION
The e2e tests now actually create 2 releases with `releaser-pleaser`.

Related to #326 