### PR TITLE
fix(gitlab): scope PendingReleases to current project

### DIFF
--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -341,7 +341,7 @@ func (g *GitLab) ClosePullRequest(ctx context.Context, pr *releasepr.ReleasePull
 
 func (g *GitLab) PendingReleases(ctx context.Context, pendingLabel releasepr.Label) ([]*releasepr.ReleasePullRequest, error) {
 	glMRs, err := all(func(listOptions gitlab.ListOptions) ([]*gitlab.BasicMergeRequest, *gitlab.Response, error) {
-		return g.client.MergeRequests.ListMergeRequests(&gitlab.ListMergeRequestsOptions{
+		return g.client.MergeRequests.ListProjectMergeRequests(g.options.Path, &gitlab.ListProjectMergeRequestsOptions{
 			State:        pointer.Pointer(PRStateMerged),
 			Labels:       &gitlab.LabelOptions{pendingLabel.Name},
 			TargetBranch: pointer.Pointer(g.options.BaseBranch),


### PR DESCRIPTION
Fixes #373.

`PendingReleases` was calling `MergeRequests.ListMergeRequests`, which maps to the instance-wide `GET /merge_requests` endpoint and returns every merged MR the token can see matching the label and target branch, regardless of project. When a single token has access to multiple projects that all use the same `rp-release::pending` label and `main` branch, pending release MRs leak across projects: a run in project A picks up a release MR from project B and then fails creating the GitLab Release with `400 Target <sha> is invalid` because the commit only exists in project B.

This PR switches to `ListProjectMergeRequests`, scoped via `g.options.Path`, so only the current project's pending releases are returned. `EnsureLabelsExist` in the same file already scopes its calls the same way, and the GitHub / Forgejo forges are inherently repo-scoped by their respective APIs, so this aligns GitLab with the rest.

## Test plan

- [x] `go build ./...` passes
- [ ] Manual: run releaser-pleaser in a project that shares a token with a sibling project carrying a `rp-release::pending` MR; confirm the sibling's MR is no longer listed and the release job succeeds.