### PR TITLE
fix: use release identity as commit committer

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -60,10 +60,6 @@ func (a Author) String() string {
 	return fmt.Sprintf("%s <%s>", a.Name, a.Email)
 }
 
-var (
-	committer = Author{Name: "releaser-pleaser", Email: ""}
-)
-
 func CloneRepo(ctx context.Context, logger *slog.Logger, cloneURL, branch string, auth transport.AuthMethod) (*Repository, error) {
 	dir, err := os.MkdirTemp("", "releaser-pleaser.*")
 	if err != nil {
@@ -175,7 +171,7 @@ func (r *Repository) Commit(_ context.Context, message string, author Author) (C
 
 	releaseCommitHash, err := worktree.Commit(message, &git.CommitOptions{
 		Author:    author.signature(now),
-		Committer: committer.signature(now),
+		Committer: author.signature(now),
 	})
 	if err != nil {
 		return Commit{}, fmt.Errorf("failed to commit changes: %w", err)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthor_signature(t *testing.T) {
@@ -171,4 +172,25 @@ func TestRepository_HasChangesWithRemote(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestRepository_CommitUsesAuthorAsCommitter(t *testing.T) {
+	repo := WithTestRepo()(t)
+	author := Author{Name: "release bot", Email: "release@example.com"}
+
+	err := repo.UpdateFile(context.Background(), "README.md", false, func(content string) (string, error) {
+		return content + "\nrelease", nil
+	})
+	require.NoError(t, err)
+
+	commit, err := repo.Commit(context.Background(), "chore: release v1.2.3", author)
+	require.NoError(t, err)
+
+	obj, err := repo.r.CommitObject(plumbing.NewHash(commit.Hash))
+	require.NoError(t, err)
+
+	assert.Equal(t, author.Name, obj.Author.Name)
+	assert.Equal(t, author.Email, obj.Author.Email)
+	assert.Equal(t, author.Name, obj.Committer.Name)
+	assert.Equal(t, author.Email, obj.Committer.Email)
 }


### PR DESCRIPTION
## Summary

- use the resolved release identity as the git committer for release commits
- remove the hardcoded `releaser-pleaser <>` committer
- add a test that verifies both author and committer fields on the created commit


## Why

Some GitLab instances enforce commit committer checks in pre-receive hooks. The previous hardcoded empty committer email caused release pushes to be rejected even when the author identity was valid.


## Notes

This updates the default committer to the resolved release identity. If backward compatibility with the old `releaser-pleaser <>` committer is needed, I can add a flag to explicitly enable it.