### PR TITLE
fix: prefer GitLab commit identity for release authors

### DIFF
--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -41,6 +41,14 @@ type GitLab struct {
 	log    *slog.Logger
 }
 
+type currentUser struct {
+	Username    string `json:"username"`
+	Name        string `json:"name"`
+	Email       string `json:"email"`
+	PublicEmail string `json:"public_email"`
+	CommitEmail string `json:"commit_email"`
+}
+
 func (g *GitLab) RepoURL() string {
 	if g.options.ProjectURL != "" {
 		return g.options.ProjectURL
@@ -72,16 +80,33 @@ func (g *GitLab) GitAuth() transport.AuthMethod {
 func (g *GitLab) CommitAuthor(ctx context.Context) (git.Author, error) {
 	g.log.DebugContext(ctx, "getting commit author from current token user")
 
-	user, _, err := g.client.Users.CurrentUser(gitlab.WithContext(ctx))
+	req, err := g.client.NewRequest("GET", "user", nil, []gitlab.RequestOptionFunc{gitlab.WithContext(ctx)})
 	if err != nil {
 		return git.Author{}, err
 	}
 
-	// TODO: Return bot when nothing is returned?
+	user := &currentUser{}
+	_, err = g.client.Do(req, user)
+	if err != nil {
+		return git.Author{}, err
+	}
+
+	name := user.Name
+	if name == "" {
+		name = user.Username
+	}
+
+	email := user.CommitEmail
+	if email == "" {
+		email = user.Email
+	}
+	if email == "" {
+		email = user.PublicEmail
+	}
 
 	return git.Author{
-		Name:  user.Name,
-		Email: user.Email,
+		Name:  name,
+		Email: email,
 	}, nil
 }
 

--- a/internal/forge/gitlab/gitlab_test.go
+++ b/internal/forge/gitlab/gitlab_test.go
@@ -1,0 +1,60 @@
+package gitlab
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitAuthor(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantName  string
+		wantEmail string
+	}{
+		{
+			name:      "prefers commit email",
+			body:      `{"username":"jdoe","name":"Jane Doe","email":"primary@example.com","public_email":"public@example.com","commit_email":"commit@example.com"}`,
+			wantName:  "Jane Doe",
+			wantEmail: "commit@example.com",
+		},
+		{
+			name:      "falls back to primary email",
+			body:      `{"username":"jdoe","name":"Jane Doe","email":"primary@example.com","public_email":"public@example.com"}`,
+			wantName:  "Jane Doe",
+			wantEmail: "primary@example.com",
+		},
+		{
+			name:      "falls back to public email and username",
+			body:      `{"username":"jdoe","public_email":"public@example.com"}`,
+			wantName:  "jdoe",
+			wantEmail: "public@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/api/v4/user", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			forge, err := New(slog.New(slog.NewTextHandler(io.Discard, nil)), &Options{APIURL: server.URL, APIToken: "token"})
+			require.NoError(t, err)
+
+			author, err := forge.CommitAuthor(context.Background())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, author.Name)
+			assert.Equal(t, tt.wantEmail, author.Email)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- read the raw GitLab [`/user`](https://docs.gitlab.com/api/users/#retrieve-the-current-user) response when resolving the release commit author
- prefer `commit_email` over `email`, with fallbacks for missing name or email fields
- add coverage for the GitLab author resolution fallback order


## Why

GitLab exposes a dedicated `commit_email` for the current user, separate from the primary account email. The previous implementation only used `email`, which made release commit authorship inaccurate whenever the GitLab commit identity differed from the primary email.

## Notes

The GitLab client used here does not expose `commit_email` on the `CurrentUser()` response type, so this change reads the raw `/user` response to access that field.