### PR TITLE
feat: add compareurl and commiturl for changelog

### DIFF
--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -34,15 +34,17 @@ type Data struct {
 	Commits     map[string][]commitparser.AnalyzedCommit
 	Version     string
 	VersionLink string
+	CompareURL  string
 	Prefix      string
 	Suffix      string
 }
 
-func New(commits map[string][]commitparser.AnalyzedCommit, version, versionLink, prefix, suffix string) Data {
+func New(commits map[string][]commitparser.AnalyzedCommit, version, versionLink, compareURL, prefix, suffix string) Data {
 	return Data{
 		Commits:     commits,
 		Version:     version,
 		VersionLink: versionLink,
+		CompareURL:  compareURL,
 		Prefix:      prefix,
 		Suffix:      suffix,
 	}

--- a/internal/changelog/changelog.md.tpl
+++ b/internal/changelog/changelog.md.tpl
@@ -1,9 +1,12 @@
 {{define "entry" -}}
-- {{ if .BreakingChange}}**BREAKING**: {{end}}{{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}}
+- {{ if .BreakingChange}}**BREAKING**: {{end}}{{ if .Scope }}**{{.Scope}}**: {{end}}{{.Description}} ([{{.ShortHash}}]({{.URL}}))
 {{ end }}
 
 {{- if not .Formatting.HideVersionTitle }}
 ## [{{.Data.Version}}]({{.Data.VersionLink}})
+{{ if .Data.CompareURL }}
+[Compare to previous version]({{.Data.CompareURL}})
+{{ end -}}
 {{ end -}}
 {{- if .Data.Prefix }}
 {{ .Data.Prefix }}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -44,7 +44,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "abc1234567890", URL: "https://example.com/commit/abc1234567890"},
 						Type:        "feat",
 						Description: "Foobar!",
 					},
@@ -52,7 +52,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 				version: "1.0.0",
 				link:    "https://example.com/1.0.0",
 			},
-			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Features\n\n- Foobar!\n",
+			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Features\n\n- Foobar! ([abc1234](https://example.com/commit/abc1234567890))\n",
 			wantErr: assert.NoError,
 		},
 		{
@@ -60,7 +60,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
 					{
-						Commit:         git.Commit{},
+						Commit:         git.Commit{Hash: "abc1234567890", URL: "https://example.com/commit/abc1234567890"},
 						Type:           "feat",
 						Description:    "Foobar!",
 						BreakingChange: true,
@@ -69,7 +69,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 				version: "1.0.0",
 				link:    "https://example.com/1.0.0",
 			},
-			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Features\n\n- **BREAKING**: Foobar!\n",
+			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Features\n\n- **BREAKING**: Foobar! ([abc1234](https://example.com/commit/abc1234567890))\n",
 			wantErr: assert.NoError,
 		},
 		{
@@ -77,7 +77,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "abc1234567890", URL: "https://example.com/commit/abc1234567890"},
 						Type:        "fix",
 						Description: "Foobar!",
 					},
@@ -85,7 +85,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 				version: "1.0.0",
 				link:    "https://example.com/1.0.0",
 			},
-			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Bug Fixes\n\n- Foobar!\n",
+			want:    "## [1.0.0](https://example.com/1.0.0)\n\n### Bug Fixes\n\n- Foobar! ([abc1234](https://example.com/commit/abc1234567890))\n",
 			wantErr: assert.NoError,
 		},
 		{
@@ -93,23 +93,23 @@ func Test_NewChangelogEntry(t *testing.T) {
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "aaa1111111111", URL: "https://example.com/commit/aaa1111111111"},
 						Type:        "feat",
 						Description: "Blabla!",
 					},
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "bbb2222222222", URL: "https://example.com/commit/bbb2222222222"},
 						Type:        "feat",
 						Description: "So awesome!",
 						Scope:       ptr("awesome"),
 					},
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "ccc3333333333", URL: "https://example.com/commit/ccc3333333333"},
 						Type:        "fix",
 						Description: "Foobar!",
 					},
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "ddd4444444444", URL: "https://example.com/commit/ddd4444444444"},
 						Type:        "fix",
 						Description: "So sad!",
 						Scope:       ptr("sad"),
@@ -122,13 +122,13 @@ func Test_NewChangelogEntry(t *testing.T) {
 
 ### Features
 
-- Blabla!
-- **awesome**: So awesome!
+- Blabla! ([aaa1111](https://example.com/commit/aaa1111111111))
+- **awesome**: So awesome! ([bbb2222](https://example.com/commit/bbb2222222222))
 
 ### Bug Fixes
 
-- Foobar!
-- **sad**: So sad!
+- Foobar! ([ccc3333](https://example.com/commit/ccc3333333333))
+- **sad**: So sad! ([ddd4444](https://example.com/commit/ddd4444444444))
 `,
 			wantErr: assert.NoError,
 		},
@@ -137,7 +137,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "abc1234567890", URL: "https://example.com/commit/abc1234567890"},
 						Type:        "fix",
 						Description: "Foobar!",
 					},
@@ -154,7 +154,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
 					{
-						Commit:      git.Commit{},
+						Commit:      git.Commit{Hash: "abc1234567890", URL: "https://example.com/commit/abc1234567890"},
 						Type:        "fix",
 						Description: "Foobar!",
 					},
@@ -170,7 +170,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := New(commitparser.ByType(tt.args.analyzedCommits), tt.args.version, tt.args.link, tt.args.prefix, tt.args.suffix)
+			data := New(commitparser.ByType(tt.args.analyzedCommits), tt.args.version, tt.args.link, "", tt.args.prefix, tt.args.suffix)
 			got, err := Entry(slog.Default(), DefaultTemplate(), data, Formatting{})
 			if !tt.wantErr(t, err) {
 				return

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -20,6 +20,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 		analyzedCommits []commitparser.AnalyzedCommit
 		version         string
 		link            string
+		compare         string
 		prefix          string
 		suffix          string
 	}
@@ -133,6 +134,23 @@ func Test_NewChangelogEntry(t *testing.T) {
 			wantErr: assert.NoError,
 		},
 		{
+			name: "compare url",
+			args: args{
+				analyzedCommits: []commitparser.AnalyzedCommit{
+					{
+						Commit:      git.Commit{Hash: "abc1234567890", URL: "https://example.com/commit/abc1234567890"},
+						Type:        "fix",
+						Description: "Foobar!",
+					},
+				},
+				version: "1.0.0",
+				link:    "https://example.com/1.0.0",
+				compare: "https://example.com/compare/0.1.0/1.0.0/",
+			},
+			want:    testdata.MustReadFileString(t, "changelog-entry-compare-url.txt"),
+			wantErr: assert.NoError,
+		},
+		{
 			name: "prefix",
 			args: args{
 				analyzedCommits: []commitparser.AnalyzedCommit{
@@ -170,7 +188,7 @@ func Test_NewChangelogEntry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := New(commitparser.ByType(tt.args.analyzedCommits), tt.args.version, tt.args.link, "", tt.args.prefix, tt.args.suffix)
+			data := New(commitparser.ByType(tt.args.analyzedCommits), tt.args.version, tt.args.link, tt.args.compare, tt.args.prefix, tt.args.suffix)
 			got, err := Entry(slog.Default(), DefaultTemplate(), data, Formatting{})
 			if !tt.wantErr(t, err) {
 				return

--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -14,6 +14,8 @@ type Forge interface {
 	CloneURL() string
 	ReleaseURL(version string) string
 	PullRequestURL(id int64) string
+	CommitURL(hash string) string
+	CompareURL(from, to string) string
 
 	GitAuth() transport.AuthMethod
 

--- a/internal/forge/forgejo/forgejo.go
+++ b/internal/forge/forgejo/forgejo.go
@@ -45,6 +45,14 @@ func (f *Forgejo) PullRequestURL(id int64) string {
 	return fmt.Sprintf("%s/pulls/%d", f.RepoURL(), id)
 }
 
+func (f *Forgejo) CommitURL(hash string) string {
+	return fmt.Sprintf("%s/commit/%s", f.RepoURL(), hash)
+}
+
+func (f *Forgejo) CompareURL(from, to string) string {
+	return fmt.Sprintf("%s/compare/%s...%s", f.RepoURL(), from, to)
+}
+
 func (f *Forgejo) GitAuth() transport.AuthMethod {
 	return &http.BasicAuth{
 		Username: f.options.Username,
@@ -134,6 +142,7 @@ func (f *Forgejo) CommitsSince(ctx context.Context, tag *git.Tag) ([]git.Commit,
 	for _, fCommit := range repositoryCommits {
 		commit := git.Commit{
 			Hash:    fCommit.SHA,
+			URL:     f.CommitURL(fCommit.SHA),
 			Message: fCommit.RepoCommit.Message,
 		}
 		commit.PullRequest, err = f.prForCommit(ctx, commit)

--- a/internal/forge/github/github.go
+++ b/internal/forge/github/github.go
@@ -61,6 +61,14 @@ func (g *GitHub) PullRequestURL(id int64) string {
 	return fmt.Sprintf("https://github.com/%s/%s/pull/%d", g.options.Owner, g.options.Repo, id)
 }
 
+func (g *GitHub) CommitURL(hash string) string {
+	return fmt.Sprintf("https://github.com/%s/%s/commit/%s", g.options.Owner, g.options.Repo, hash)
+}
+
+func (g *GitHub) CompareURL(from, to string) string {
+	return fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s", g.options.Owner, g.options.Repo, from, to)
+}
+
 func (g *GitHub) GitAuth() transport.AuthMethod {
 	return &http.BasicAuth{
 		Username: g.options.Username,
@@ -147,6 +155,7 @@ func (g *GitHub) CommitsSince(ctx context.Context, tag *git.Tag) ([]git.Commit, 
 	for _, ghCommit := range repositoryCommits {
 		commit := git.Commit{
 			Hash:    ghCommit.GetSHA(),
+			URL:     g.CommitURL(ghCommit.GetSHA()),
 			Message: ghCommit.GetCommit().GetMessage(),
 		}
 		commit.PullRequest, err = g.prForCommit(ctx, commit)

--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -61,6 +61,14 @@ func (g *GitLab) PullRequestURL(id int64) string {
 	return fmt.Sprintf("%s/-/merge_requests/%d", g.RepoURL(), id)
 }
 
+func (g *GitLab) CommitURL(hash string) string {
+	return fmt.Sprintf("%s/-/commit/%s", g.RepoURL(), hash)
+}
+
+func (g *GitLab) CompareURL(from, to string) string {
+	return fmt.Sprintf("%s/-/compare/%s...%s", g.RepoURL(), from, to)
+}
+
 func (g *GitLab) GitAuth() transport.AuthMethod {
 	return &http.BasicAuth{
 		// Username just needs to be any non-blank value
@@ -160,6 +168,7 @@ func (g *GitLab) CommitsSince(ctx context.Context, tag *git.Tag) ([]git.Commit, 
 	for _, ghCommit := range gitLabCommits {
 		commit := git.Commit{
 			Hash:    ghCommit.ID,
+			URL:     g.CommitURL(ghCommit.ID),
 			Message: ghCommit.Message,
 		}
 		commit.PullRequest, err = g.prForCommit(ctx, commit)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -22,9 +22,17 @@ const (
 
 type Commit struct {
 	Hash    string
+	URL     string
 	Message string
 
 	PullRequest *PullRequest
+}
+
+func (c Commit) ShortHash() string {
+	if len(c.Hash) <= 7 {
+		return c.Hash
+	}
+	return c.Hash[:7]
 }
 
 type PullRequest struct {

--- a/internal/testdata/changelog-entry-compare-url.txt
+++ b/internal/testdata/changelog-entry-compare-url.txt
@@ -1,0 +1,7 @@
+## [1.0.0](https://example.com/1.0.0)
+
+[Compare to previous version](https://example.com/compare/0.1.0/1.0.0/)
+
+### Bug Fixes
+
+- Foobar! ([abc1234](https://example.com/commit/abc1234567890))

--- a/internal/testdata/changelog-entry-prefix.txt
+++ b/internal/testdata/changelog-entry-prefix.txt
@@ -16,4 +16,4 @@ func IsPositive(number int) error {
 
 ### Bug Fixes
 
-- Foobar!
+- Foobar! ([abc1234](https://example.com/commit/abc1234567890))

--- a/internal/testdata/changelog-entry-suffix.txt
+++ b/internal/testdata/changelog-entry-suffix.txt
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-- Foobar!
+- Foobar! ([abc1234](https://example.com/commit/abc1234567890))
 
 ## Compatibility
 

--- a/releaserpleaser.go
+++ b/releaserpleaser.go
@@ -249,12 +249,19 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 	}
 	logger.InfoContext(ctx, "next version", "version", nextVersion)
 
+	changelogBaseTag := releases.Stable
 	analyzedCommitsForChangelog := analyzedCommitsForVersioning
 	if releaseOverrides.NextVersionType.IsPrerelease() && releases.Latest != releases.Stable {
+		changelogBaseTag = releases.Latest
 		analyzedCommitsForChangelog, err = rp.analyzedCommitsSince(ctx, releases.Latest)
 		if err != nil {
 			return err
 		}
+	}
+
+	var compareURL string
+	if changelogBaseTag != nil {
+		compareURL = rp.forge.CompareURL(changelogBaseTag.Name, nextVersion)
 	}
 
 	logger.DebugContext(ctx, "cloning repository", "clone.url", rp.forge.CloneURL())
@@ -271,7 +278,7 @@ func (rp *ReleaserPleaser) runReconcileReleasePR(ctx context.Context) error {
 		return err
 	}
 
-	changelogData := changelog.New(commitparser.ByType(analyzedCommitsForChangelog), nextVersion, rp.forge.ReleaseURL(nextVersion), releaseOverrides.Prefix, releaseOverrides.Suffix)
+	changelogData := changelog.New(commitparser.ByType(analyzedCommitsForChangelog), nextVersion, rp.forge.ReleaseURL(nextVersion), compareURL, releaseOverrides.Prefix, releaseOverrides.Suffix)
 
 	changelogEntry, err := changelog.Entry(logger, changelog.DefaultTemplate(), changelogData, changelog.Formatting{})
 	if err != nil {


### PR DESCRIPTION
Adds commit and compare URLs to the rendered changelog: each entry links to its commit via a short-hash reference, and a 'Compare to previous version' link is included beneath the version heading. The compare URL is built from the previous release tag (stable or latest for prereleases) to the next version.