### PR TITLE
fix(markdown): tolerate whitespace-stripped section-marker HTML comments

### DIFF
--- a/internal/markdown/extensions/section.go
+++ b/internal/markdown/extensions/section.go
@@ -14,9 +14,16 @@ import (
 	"github.com/apricote/releaser-pleaser/internal/markdown/extensions/ast"
 )
 
+// Section-start/end markers are emitted with a space on each side of the
+// keyword (see SectionStartFormat / SectionEndFormat) so they round-trip
+// through standard markdown tooling. GitLab's web-UI markdown editor, however,
+// normalises HTML comments by stripping inner whitespace when a user edits the
+// release-MR description — so `<!-- section-start changelog -->` comes back as
+// `<!--section-start changelog-->` and stops matching a strict regex. The
+// parser accepts both forms; the renderer still emits the canonical spaced form.
 var (
-	sectionStartRegex = regexp.MustCompile(`^<!-- section-start (.+) -->`)
-	sectionEndRegex   = regexp.MustCompile(`^<!-- section-end (.+) -->`)
+	sectionStartRegex = regexp.MustCompile(`^<!--\s*section-start\s+(.+?)\s*-->`)
+	sectionEndRegex   = regexp.MustCompile(`^<!--\s*section-end\s+(.+?)\s*-->`)
 )
 
 const (

--- a/internal/markdown/goldmark_test.go
+++ b/internal/markdown/goldmark_test.go
@@ -182,6 +182,20 @@ func TestGetSectionText(t *testing.T) {
 			want:    "Content\n",
 			wantErr: assert.NoError,
 		},
+		{
+			// GitLab's web-UI markdown editor strips whitespace inside HTML
+			// comments when a user edits the release-MR description, turning
+			// `<!-- section-start x -->` into `<!--section-start x-->`. The
+			// parser must accept that form or the release description ends up
+			// empty. https://github.com/apricote/releaser-pleaser/issues/TBD
+			name: "section with whitespace stripped from comment markers",
+			args: args{
+				source: []byte("<!--section-start test-->\nContent\n<!--section-end test-->"),
+				name:   "test",
+			},
+			want:    "Content\n",
+			wantErr: assert.NoError,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

When the release-MR description is edited via GitLab's web UI (the normal path for filling in an `rp-prefix` / `rp-suffix` override), GitLab normalises HTML comments by stripping the inner whitespace. The canonical form

```
<!-- section-start changelog -->
### Features
- something
<!-- section-end changelog -->
```

comes back as

```
<!--section-start changelog-->
### Features
- something
<!--section-end changelog-->
```

The current section-marker regexes in `internal/markdown/extensions/section.go` require literal spaces:

```go
sectionStartRegex = regexp.MustCompile(`^<!-- section-start (.+) -->`)
sectionEndRegex   = regexp.MustCompile(`^<!-- section-end (.+) -->`)
```

Once those don't match, `pr.ChangelogText()` returns `""` and `forge.CreateRelease(..., changelogText, ...)` writes an empty description to the GitLab Release — which also cascades into any downstream tooling that reads the release body (Linear release notes, Slack announcements, etc.). The release still gets tagged, so the failure is silent from the pipeline's perspective — the human just sees a blank Release page.

## Repro

1. In a GitLab project consuming the releaser-pleaser CI/CD component, let it open a release MR.
2. Edit the MR description via the GitLab web UI (e.g. paste content into the ```` ```rp-prefix ```` block).
3. Merge.
4. Observe the GitLab Release description is empty even though the MR's `<!--section-start changelog-->` block contained the changelog.

## Fix

Widen both regexes to accept optional whitespace around the keyword, using non-greedy capture so a name with trailing whitespace still round-trips cleanly:

```go
sectionStartRegex = regexp.MustCompile(`^<!--\s*section-start\s+(.+?)\s*-->`)
sectionEndRegex   = regexp.MustCompile(`^<!--\s*section-end\s+(.+?)\s*-->`)
```

The renderer still emits the canonical spaced form (`SectionStartFormat` / `SectionEndFormat` are unchanged), so the on-disk / on-forge output is byte-identical to before. Only parsing is more forgiving. A comment on the regex block explains the reason so future readers don't tighten it back.

## Tests

Added a `TestGetSectionText` case covering the GitLab-normalised form:

```go
{
    name: "section with whitespace stripped from comment markers",
    args: args{
        source: []byte("<!--section-start test-->\nContent\n<!--section-end test-->"),
        name:   "test",
    },
    want:    "Content\n",
    wantErr: assert.NoError,
},
```

`go test ./...` is green.