### PR TITLE
fix(gitlab): resolve the release commit after an automatic rebase

### DIFF
--- a/internal/forge/gitlab/gitlab.go
+++ b/internal/forge/gitlab/gitlab.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/go-git/go-git/v5/plumbing/transport"
@@ -364,10 +365,146 @@ func (g *GitLab) PendingReleases(ctx context.Context, pendingLabel releasepr.Lab
 	prs := make([]*releasepr.ReleasePullRequest, 0, len(glMRs))
 
 	for _, mr := range glMRs {
-		prs = append(prs, gitlabMRToReleasePullRequest(mr))
+		pr := gitlabMRToReleasePullRequest(mr)
+
+		// On a fast-forward merge GitLab records neither a merge commit nor a
+		// squash commit, so gitlabMRToReleasePullRequest falls back to the merge
+		// request's recorded head. Since GitLab 19.2 a project can enable
+		// "Enable automatic rebase prior to merge", which rebases a merge
+		// request that is behind its target branch as part of merging it. That
+		// rebase is never written back to the merge request, so the recorded
+		// head is the PRE-rebase commit and is on no branch at all. Releasing
+		// there silently drops everything that landed while the merge request
+		// was open.
+		//
+		// Only the fallback needs checking; a merge or squash commit is on the
+		// target branch by construction, so projects using those merge methods
+		// make no additional requests.
+		usedRecordedHeadFallback := mr.MergeCommitSHA == "" && mr.SquashCommitSHA == ""
+		if usedRecordedHeadFallback && pr.ReleaseCommit != nil {
+			commit, err := g.resolveReleaseCommit(ctx, mr, pr.ReleaseCommit.Hash)
+			if err != nil {
+				return nil, err
+			}
+
+			pr.ReleaseCommit = &git.Commit{Hash: commit}
+		}
+
+		prs = append(prs, pr)
 	}
 
 	return prs, nil
+}
+
+// rebasedCommitSearchWindow bounds the commit search used to recover the commit
+// an automatic rebase produced. The rebase happens as part of the merge, so the
+// resulting commit is committed within seconds of MergedAt; the window is
+// generous only to tolerate clock skew.
+const rebasedCommitSearchWindow = 10 * time.Minute
+
+// resolveReleaseCommit returns the commit the merge request actually landed as
+// on the target branch.
+//
+// candidate is the merge request's recorded head. Usually that is exactly what
+// landed and it is returned unchanged. When the project rebased the branch
+// while merging it, the recorded head is stale and the commit that landed is
+// recovered instead.
+func (g *GitLab) resolveReleaseCommit(ctx context.Context, mr *gitlab.BasicMergeRequest, candidate string) (string, error) {
+	onBranch, err := g.commitOnBranch(ctx, candidate, g.options.BaseBranch)
+	if err != nil {
+		return "", fmt.Errorf("failed to check if commit %s is on %s: %w", candidate, g.options.BaseBranch, err)
+	}
+
+	if onBranch {
+		return candidate, nil
+	}
+
+	g.log.DebugContext(ctx, "merge request head is not on the target branch, looking for the rebased commit",
+		"mr.iid", mr.IID, "mr.sha", candidate, "branch", g.options.BaseBranch)
+
+	rebased, err := g.findRebasedCommit(ctx, mr)
+	if err != nil {
+		return "", err
+	}
+
+	if rebased == "" {
+		return "", fmt.Errorf(
+			"release commit %s for %q is not on %s and the commit it was rebased to could not be found. "+
+				"The merge request was rebased while being merged, so its recorded head is the pre-rebase "+
+				"commit; releasing there would omit everything merged while the release merge request was open",
+			candidate, mr.Title, g.options.BaseBranch,
+		)
+	}
+
+	g.log.InfoContext(ctx, "recovered rebased release commit",
+		"mr.iid", mr.IID, "mr.sha", candidate, "commit.hash", rebased)
+
+	return rebased, nil
+}
+
+// findRebasedCommit locates the commit on the target branch that the merge
+// request landed as, after GitLab rebased it during the merge.
+//
+// A rebase preserves the commit message, and GitLab associates the resulting
+// commit with the merge request, so a commit is only accepted when its title
+// matches AND the association confirms it.
+func (g *GitLab) findRebasedCommit(ctx context.Context, mr *gitlab.BasicMergeRequest) (string, error) {
+	if mr.MergedAt == nil {
+		return "", nil
+	}
+
+	since := mr.MergedAt.Add(-rebasedCommitSearchWindow)
+	until := mr.MergedAt.Add(rebasedCommitSearchWindow)
+
+	commits, err := all(func(listOptions gitlab.ListOptions) ([]*gitlab.Commit, *gitlab.Response, error) {
+		return g.client.Commits.ListCommits(g.options.Path, &gitlab.ListCommitsOptions{
+			RefName:     pointer.Pointer(g.options.BaseBranch),
+			Since:       &since,
+			Until:       &until,
+			ListOptions: listOptions,
+		}, gitlab.WithContext(ctx))
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list commits on %s: %w", g.options.BaseBranch, err)
+	}
+
+	for _, commit := range commits {
+		if commit.Title != mr.Title {
+			continue
+		}
+
+		associated, _, err := g.client.Commits.ListMergeRequestsByCommit(
+			g.options.Path, commit.ID, gitlab.WithContext(ctx),
+		)
+		if err != nil {
+			return "", fmt.Errorf("failed to list merge requests for commit %s: %w", commit.ID, err)
+		}
+
+		if slices.ContainsFunc(associated, func(candidate *gitlab.BasicMergeRequest) bool {
+			return candidate.IID == mr.IID
+		}) {
+			return commit.ID, nil
+		}
+	}
+
+	return "", nil
+}
+
+// commitOnBranch reports whether the commit is contained in the named branch.
+func (g *GitLab) commitOnBranch(ctx context.Context, sha, branch string) (bool, error) {
+	refs, err := all(func(listOptions gitlab.ListOptions) ([]*gitlab.CommitRef, *gitlab.Response, error) {
+		return g.client.Commits.GetCommitRefs(g.options.Path, sha, &gitlab.GetCommitRefsOptions{
+			Type:        pointer.Pointer("branch"),
+			ListOptions: listOptions,
+		}, gitlab.WithContext(ctx))
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return slices.ContainsFunc(refs, func(ref *gitlab.CommitRef) bool {
+		return ref.Name == branch
+	}), nil
 }
 
 func (g *GitLab) CreateRelease(ctx context.Context, commit git.Commit, title, changelog string, _, _ bool) error {

--- a/internal/forge/gitlab/gitlab_ff_test.go
+++ b/internal/forge/gitlab/gitlab_ff_test.go
@@ -1,0 +1,260 @@
+package gitlab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/apricote/releaser-pleaser/internal/forge"
+	"github.com/apricote/releaser-pleaser/internal/releasepr"
+)
+
+// Commit graph of the scenario, which is ordinary practice on a project using
+// the fast-forward merge method:
+//
+//	A   ── base of the Release MR when releaser-pleaser opened it
+//	 \
+//	  A' ── the release commit, HEAD of releaser-pleaser--branches--main
+//
+//	A ── B          another MR merges to main while the Release MR is open
+//	      \
+//	       B'       merging the Release MR fast-forwards: GitLab REBASES A'
+//	                onto B, main becomes B'
+//
+// After that merge GitLab reports, on the merge request:
+//
+//	sha               = A'   (the PRE-rebase head — never updated)
+//	merge_commit_sha  = null (fast-forward: no merge commit)
+//	squash_commit_sha = null (squash not required on the project)
+//
+// B' is the commit that actually landed on main. A' is on no branch at all.
+const (
+	branchMain = "main"
+
+	commitPreRebaseReleaseHead = "1c17efd18edcf465c3355653b2cd171d67f1bf2e" // A'
+	commitOnMainAfterMerge     = "dd4b82efa9e9c24f192da30a970376e53333b27b" // B'
+
+	releaseVersion = "v0.12.1"
+)
+
+// fakeGitLab serves the handful of endpoints PendingReleases and CreateRelease
+// touch, reproducing the API responses a real fast-forward merge leaves behind.
+// The SHAs above are the real ones from gitlab.com/phpboyscout/go/config!94.
+func fakeGitLab(t *testing.T, squashCommitSHA, recordedHead string) (*httptest.Server, *string) {
+	t.Helper()
+
+	// Captures the ref releaser-pleaser asks GitLab to create the tag at.
+	var createdReleaseRef string
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /api/v4/projects/{project}/merge_requests", func(w http.ResponseWriter, _ *http.Request) {
+		mr := map[string]any{
+			"iid":               94,
+			"title":             fmt.Sprintf("chore(main): release %s", releaseVersion),
+			"description":       "",
+			"state":             "merged",
+			"labels":            []string{releasepr.LabelReleasePending.Name},
+			"target_branch":     branchMain,
+			"source_branch":     "releaser-pleaser--branches--main",
+			"merged_at":         "2026-07-31T08:32:52.536Z",
+			"sha":               recordedHead,
+			"merge_commit_sha":  "", // fast-forward merge: no merge commit
+			"squash_commit_sha": squashCommitSHA,
+		}
+		writeJSON(t, w, []any{mr})
+	})
+
+	// Commits on the target branch in the merge window. After an automatic
+	// rebase the landed commit keeps the merge request's message.
+	mux.HandleFunc("GET /api/v4/projects/{project}/repository/commits", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, []any{map[string]any{
+			"id":             commitOnMainAfterMerge,
+			"title":          fmt.Sprintf("chore(main): release %s", releaseVersion),
+			"committed_date": "2026-07-31T08:32:51.000Z",
+		}})
+	})
+
+	// GitLab associates the rebased commit with the merge request it came from.
+	mux.HandleFunc("GET /api/v4/projects/{project}/repository/commits/{sha}/merge_requests", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, []any{map[string]any{"iid": 94, "title": fmt.Sprintf("chore(main): release %s", releaseVersion)}})
+	})
+
+	// Only commitOnMainAfterMerge is on a branch. The pre-rebase head is on
+	// none, which is exactly the state GitLab leaves after rebasing to
+	// fast-forward.
+	mux.HandleFunc("GET /api/v4/projects/{project}/repository/commits/{sha}/refs", func(w http.ResponseWriter, r *http.Request) {
+		if r.PathValue("sha") == commitOnMainAfterMerge {
+			writeJSON(t, w, []any{map[string]any{"type": "branch", "name": branchMain}})
+			return
+		}
+		writeJSON(t, w, []any{})
+	})
+
+	mux.HandleFunc("POST /api/v4/projects/{project}/releases", func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading release request body: %v", err)
+		}
+		var opts struct {
+			Ref     string `json:"ref"`
+			TagName string `json:"tag_name"`
+		}
+		if err := json.Unmarshal(body, &opts); err != nil {
+			t.Errorf("decoding release request body: %v", err)
+		}
+		createdReleaseRef = opts.Ref
+		writeJSON(t, w, map[string]any{"tag_name": opts.TagName})
+	})
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to fake GitLab: %s %s", r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	return srv, &createdReleaseRef
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encoding response: %v", err)
+	}
+}
+
+func newTestGitLab(t *testing.T, apiURL string) *GitLab {
+	t.Helper()
+
+	// autodiscover() reads these from the environment and would otherwise
+	// override the options below when the tests run inside GitLab CI.
+	t.Setenv(EnvAPIURL, "")
+	t.Setenv(EnvAPIToken, "")
+	t.Setenv(EnvProjectURL, "")
+	t.Setenv(EnvProjectPath, "")
+
+	gl, err := New(slog.New(slog.DiscardHandler), &Options{
+		Options:  forge.Options{Repository: "phpboyscout/go/config", BaseBranch: branchMain},
+		Path:     "phpboyscout/go/config",
+		APIURL:   apiURL + "/api/v4",
+		APIToken: "test-token",
+	})
+	if err != nil {
+		t.Fatalf("constructing GitLab forge: %v", err)
+	}
+
+	return gl
+}
+
+// TestPendingReleases_AutomaticRebaseRecoversTheLandedCommit is the regression
+// test for the defect.
+//
+// GitLab 19.2 added "Enable automatic rebase prior to merge", which rebases a
+// merge request that is behind its target branch as part of merging it. The
+// rebase is not written back to the merge request, so its recorded head is the
+// PRE-rebase commit — which is on no branch. #210 made that recorded head the
+// release commit for fast-forward projects, so the tag lands on a commit that
+// is not on the target branch and the release silently omits everything that
+// merged while the release merge request was open.
+//
+// Nothing fails today: the merge request merges green, the tag is created, the
+// release page appears, and only the tagged tree is wrong.
+//
+// The release must still be cut — refusing would block every release on a
+// project using automatic rebase — but at the commit that actually landed.
+func TestPendingReleases_AutomaticRebaseRecoversTheLandedCommit(t *testing.T) {
+	srv, createdReleaseRef := fakeGitLab(t, "", commitPreRebaseReleaseHead)
+	gl := newTestGitLab(t, srv.URL)
+
+	prs, err := gl.PendingReleases(context.Background(), releasepr.LabelReleasePending)
+	if err != nil {
+		t.Fatalf("PendingReleases: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 pending release, got %d", len(prs))
+	}
+	if prs[0].ReleaseCommit == nil {
+		t.Fatal("pending release has no release commit")
+	}
+
+	if err := gl.CreateRelease(
+		context.Background(), *prs[0].ReleaseCommit, releaseVersion, "changelog", false, true,
+	); err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+
+	if *createdReleaseRef != commitOnMainAfterMerge {
+		t.Errorf(
+			"release %s was created at %s, but the commit that landed on %s is %s\n"+
+				"the tag names a commit that is not on %s, so the released tree is missing\n"+
+				"everything that merged while the release merge request was open",
+			releaseVersion, *createdReleaseRef, branchMain, commitOnMainAfterMerge, branchMain,
+		)
+	}
+}
+
+// TestPendingReleases_FastForwardUpToDateMergeStillReleases guards the fix
+// against over-reach: when the release merge request was NOT behind the target
+// branch, a fast-forward merge lands its recorded head unchanged, that commit
+// is on the branch, and the release must still be created there. This is the
+// case #210 set out to support, and it must keep working.
+func TestPendingReleases_FastForwardUpToDateMergeStillReleases(t *testing.T) {
+	srv, createdReleaseRef := fakeGitLab(t, "", commitOnMainAfterMerge)
+	gl := newTestGitLab(t, srv.URL)
+
+	prs, err := gl.PendingReleases(context.Background(), releasepr.LabelReleasePending)
+	if err != nil {
+		t.Fatalf("PendingReleases rejected a fast-forward merge whose head IS on %s: %v", branchMain, err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 pending release, got %d", len(prs))
+	}
+
+	if err := gl.CreateRelease(
+		context.Background(), *prs[0].ReleaseCommit, releaseVersion, "changelog", false, true,
+	); err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+
+	if *createdReleaseRef != commitOnMainAfterMerge {
+		t.Errorf("release created at %s, want %s", *createdReleaseRef, commitOnMainAfterMerge)
+	}
+}
+
+// TestPendingReleases_SquashedMergeTagsCommitOnTargetBranch is the control.
+//
+// With squashing enabled GitLab records a squash_commit_sha, which it creates
+// on top of the CURRENT target head — so it is on the branch by construction
+// and releaser-pleaser resolves it correctly. This passes both before and after
+// the fix, and shows the defect is specific to the fast-forward-without-squash
+// path.
+func TestPendingReleases_SquashedMergeTagsCommitOnTargetBranch(t *testing.T) {
+	srv, createdReleaseRef := fakeGitLab(t, commitOnMainAfterMerge, commitPreRebaseReleaseHead)
+	gl := newTestGitLab(t, srv.URL)
+
+	prs, err := gl.PendingReleases(context.Background(), releasepr.LabelReleasePending)
+	if err != nil {
+		t.Fatalf("PendingReleases: %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 pending release, got %d", len(prs))
+	}
+
+	if err := gl.CreateRelease(
+		context.Background(), *prs[0].ReleaseCommit, releaseVersion, "changelog", false, true,
+	); err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+
+	if *createdReleaseRef != commitOnMainAfterMerge {
+		t.Errorf("release created at %s, want %s", *createdReleaseRef, commitOnMainAfterMerge)
+	}
+}


### PR DESCRIPTION
GitLab 19.2 added "Enable automatic rebase prior to merge", which rebases a merge request that is behind its target branch as part of merging it.

On a fast-forward merge GitLab records neither a merge commit nor a squash commit, so the release commit falls back to the merge request's recorded head (#210). That rebase is never written back to the merge request, so the recorded head is the PRE-rebase commit — a commit that is on no branch at all.

releaser-pleaser then creates the tag there, and the release silently omits everything that landed while the release merge request was open. Nothing fails: the merge request merges green, the tag is created, the release page appears, and only the tagged tree is wrong.

The release branch is routinely behind, so this is not an edge case: since #114 the branch is only force-pushed when the release commit's own patch changes, so any commit that does not alter the changelog leaves it on its old base — which is exactly what the merge then rebases.

Recover the commit that actually landed rather than refusing to release, because refusing would block every release on a project using automatic rebase. When the recorded head is not on the target branch, search the target branch around the merge for a commit whose message matches the merge request and which GitLab associates with it. Both conditions must hold before the commit is accepted; if none is found the release fails with an explanation instead of being cut at the wrong commit.

Projects using merge commits or squashing are unaffected and make no additional API calls: those commits are on the target branch by construction.